### PR TITLE
Performance Improvements

### DIFF
--- a/server/bench.sh
+++ b/server/bench.sh
@@ -9,6 +9,7 @@ Arguments:
   SOURCE_DIRECTORY           Source directory for transfer (required).
 
 Options:
+  --rsync                    Run an rsync baseline instead of a pinch transfer.
   --flamegraph               Run start benchmark under perf and emit flamegraph SVG.
   --trace                    Capture runtime/trace for client and server (view with go tool trace).
   --build                    Build ./pinch before benchmarking (default: true).

--- a/server/bench.sh
+++ b/server/bench.sh
@@ -54,6 +54,7 @@ require_value() {
 BUILD=true
 FLAMEGRAPH=false
 TRACE=false
+RSYNC=false
 SERVER_URL="127.0.0.1:3453"
 SERVER_STARTUP_TIMEOUT_SEC=30
 SOURCE_DIRECTORY=""
@@ -87,6 +88,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --flamegraph)
       FLAMEGRAPH=true
+      shift
+      ;;
+    --rsync)
+      RSYNC=true
       shift
       ;;
     --trace)
@@ -199,6 +204,29 @@ if [[ -n "${ENCRYPT_MODE}" && "${ENCRYPT_MODE}" != "age" ]]; then
   echo "unsupported --encrypt value: ${ENCRYPT_MODE} (only 'age' is supported)" >&2
   exit 2
 fi
+
+# ── rsync baseline mode ──────────────────────────────────────────────────
+if [[ "${RSYNC}" == "true" ]]; then
+  require_cmd rsync
+  echo "bench (rsync baseline): source=${SOURCE_DIRECTORY} target=${OUT_ROOT}"
+  if [[ "${OUT_ROOT%/}" != "/dev/null" ]]; then
+    rm -rf "${OUT_ROOT}/"
+    mkdir -p "${OUT_ROOT}"
+  fi
+
+  RSYNC_CMD=(rsync -aW --no-compress --info=progress2)
+  if [[ "${NO_SYNC}" != "true" ]]; then
+    RSYNC_CMD+=(--fsync)
+  fi
+  # Trailing slash on source so rsync copies contents, not the directory itself.
+  RSYNC_CMD+=("${SOURCE_DIRECTORY%/}/" "${OUT_ROOT%/}/")
+
+  echo "Running: ${RSYNC_CMD[*]}"
+  { time "${RSYNC_CMD[@]}"; } 2>&1
+  exit 0
+fi
+
+# ── pinch mode ────────────────────────────────────────────────────────────
 if [[ "$BUILD" == "true" ]]; then
   echo "Building pinch..."
   go build -o pinch

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -312,6 +312,21 @@ type FetchManifestResponse struct {
 	Manifest *Manifest
 }
 
+type SyncManifestRequest struct {
+	Directory    string
+	OldManifest  *Manifest
+	Mode         string
+	LinkMbps     int64
+	Concurrency  int
+	AgePublicKey string
+	AgeIdentity  string
+}
+
+type SyncManifestResponse struct {
+	Manifest     *Manifest
+	RemovedPaths []string
+}
+
 type FetchFileRequest struct {
 	TransferID   string
 	Files        []FetchFileTarget
@@ -462,6 +477,31 @@ func (c *Client) FetchManifest(ctx context.Context, request FetchManifestRequest
 		return FetchManifestResponse{}, errors.New("concurrency must be > 0")
 	}
 	return c.fetchManifestTCP(ctx, request)
+}
+
+func (c *Client) SyncManifest(ctx context.Context, request SyncManifestRequest) (SyncManifestResponse, error) {
+	ctx, task := trace.NewTask(ctx, "sync-manifest")
+	defer task.End()
+	if c == nil {
+		return SyncManifestResponse{}, errors.New("nil client")
+	}
+	if request.Directory == "" {
+		return SyncManifestResponse{}, errors.New("missing directory")
+	}
+	if request.OldManifest == nil {
+		return SyncManifestResponse{}, errors.New("missing old manifest")
+	}
+	request.Mode = strings.ToLower(strings.TrimSpace(request.Mode))
+	if request.Mode != LoadStrategyFast && request.Mode != LoadStrategyGentle {
+		return SyncManifestResponse{}, errors.New("invalid mode")
+	}
+	if request.LinkMbps < 0 {
+		return SyncManifestResponse{}, errors.New("link mbps must be >= 0")
+	}
+	if request.Concurrency <= 0 {
+		return SyncManifestResponse{}, errors.New("concurrency must be > 0")
+	}
+	return c.syncManifestTCP(ctx, request)
 }
 
 func DefaultClientConcurrency() int {
@@ -2038,18 +2078,18 @@ func parseManifest(raw []byte) (*Manifest, error) {
 		trimmed := strings.TrimSpace(line)
 		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
 			if strings.HasPrefix(trimmed, "FM/2 ") {
-				txferID, root, mode, linkMbps, concurrency, parseErr := parseManifestHeader(trimmed)
+				hdr, parseErr := intencoding.ParseManifestHeader(trimmed)
 				if parseErr != nil {
 					return nil, parseErr
 				}
 				if !seenHeader {
-					manifest.TransferID = txferID
-					manifest.Root = root
-					manifest.Mode = mode
-					manifest.LinkMbps = linkMbps
-					manifest.Concurrency = concurrency
+					manifest.TransferID = hdr.TransferID
+					manifest.Root = hdr.Root
+					manifest.Mode = hdr.Mode
+					manifest.LinkMbps = hdr.LinkMbps
+					manifest.Concurrency = hdr.Concurrency
 					seenHeader = true
-				} else if manifest.TransferID != txferID || manifest.Root != root || manifest.Mode != mode || manifest.LinkMbps != linkMbps || manifest.Concurrency != concurrency {
+				} else if manifest.TransferID != hdr.TransferID || manifest.Root != hdr.Root || manifest.Mode != hdr.Mode || manifest.LinkMbps != hdr.LinkMbps || manifest.Concurrency != hdr.Concurrency {
 					return nil, errors.New("manifest chunk header mismatch")
 				}
 				prevPath = ""
@@ -2058,9 +2098,16 @@ func parseManifest(raw []byte) (*Manifest, error) {
 				if !seenHeader {
 					return nil, errors.New("manifest entry before header")
 				}
-				entry, nextPath, nextMtime, parseErr := parseManifestEntry(trimmed, prevPath, prevMtime)
+				raw, nextPath, nextMtime, parseErr := intencoding.ParseManifestEntry(trimmed, prevPath, prevMtime)
 				if parseErr != nil {
 					return nil, parseErr
+				}
+				entry := ManifestEntry{
+					ID:    raw.ID,
+					Size:  raw.Size,
+					Mtime: raw.Mtime,
+					Mode:  raw.Mode,
+					Path:  raw.Path,
 				}
 				if _, exists := seenIDs[entry.ID]; exists {
 					return nil, fmt.Errorf("duplicate manifest id: %d", entry.ID)
@@ -2101,7 +2148,6 @@ func marshalManifest(manifest *Manifest) ([]byte, error) {
 	}
 	entries := append([]ManifestEntry(nil), manifest.Entries...)
 	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
-	var b strings.Builder
 	mode := strings.ToLower(strings.TrimSpace(manifest.Mode))
 	if mode != LoadStrategyFast && mode != LoadStrategyGentle {
 		return nil, errors.New("manifest mode must be fast or gentle")
@@ -2112,16 +2158,16 @@ func marshalManifest(manifest *Manifest) ([]byte, error) {
 	if manifest.Concurrency <= 0 {
 		return nil, errors.New("manifest concurrency must be > 0")
 	}
-	fmt.Fprintf(
-		&b,
-		"FM/2 %s %d:%s mode=%s link-mbps=%d concurrency=%d\n",
-		manifest.TransferID,
-		len(manifest.Root),
-		manifest.Root,
-		mode,
-		manifest.LinkMbps,
-		manifest.Concurrency,
-	)
+	var b strings.Builder
+	hdr := intencoding.FormatManifestHeader(intencoding.ManifestHeader{
+		TransferID:  manifest.TransferID,
+		Root:        manifest.Root,
+		Mode:        mode,
+		LinkMbps:    manifest.LinkMbps,
+		Concurrency: manifest.Concurrency,
+	})
+	b.WriteString(hdr)
+	b.WriteByte('\n')
 	prevPath := ""
 	prevMtime := ""
 	seenIDs := make(map[uint64]struct{}, len(entries))
@@ -2133,69 +2179,24 @@ func marshalManifest(manifest *Manifest) ([]byte, error) {
 		if i > 0 && entry.ID <= entries[i-1].ID {
 			return nil, fmt.Errorf("manifest ids must be increasing: prev=%d curr=%d", entries[i-1].ID, entry.ID)
 		}
-		if entry.Size < 0 {
-			return nil, fmt.Errorf("manifest size must be >= 0 for id=%d", entry.ID)
-		}
-		if strings.Contains(entry.Path, `\`) {
-			return nil, fmt.Errorf("manifest path contains backslash: %q", entry.Path)
-		}
-		if strings.HasPrefix(entry.Path, "/") {
-			return nil, fmt.Errorf("manifest path must be relative: %q", entry.Path)
-		}
-		cleanPath := filepath.Clean(filepath.FromSlash(entry.Path))
-		if cleanPath == "." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) || cleanPath == ".." {
-			return nil, fmt.Errorf("manifest path traversal is not allowed: %q", entry.Path)
-		}
-		modeToken := fmt.Sprintf("%04o", uint32(entry.Mode&0o7777))
-		mtimeRaw := strconv.FormatInt(entry.Mtime, 10)
-		mtimeToken, err := encodeMtimeToken(prevMtime, mtimeRaw)
+		line, nextPath, nextMtime, err := intencoding.MarshalManifestEntry(intencoding.ManifestEntry{
+			ID:    entry.ID,
+			Size:  entry.Size,
+			Mtime: entry.Mtime,
+			Mode:  entry.Mode,
+			Path:  entry.Path,
+		}, prevPath, prevMtime)
 		if err != nil {
-			return nil, fmt.Errorf("encode manifest mtime id=%d: %w", entry.ID, err)
+			return nil, err
 		}
-		pathToken := encodePathToken(prevPath, entry.Path)
-		fmt.Fprintf(&b, "%d %d %s %s %s\n", entry.ID, entry.Size, mtimeToken, modeToken, pathToken)
-		prevPath = entry.Path
-		prevMtime = mtimeRaw
+		b.WriteString(line)
+		b.WriteByte('\n')
+		prevPath = nextPath
+		prevMtime = nextMtime
 	}
 	return []byte(b.String()), nil
 }
 
-func encodeMtimeToken(prev string, current string) (string, error) {
-	if current == "" {
-		return "", errors.New("empty mtime")
-	}
-	for _, ch := range current {
-		if ch < '0' || ch > '9' {
-			return "", errors.New("mtime must be decimal digits")
-		}
-	}
-	prefixLen := commonPrefixLen(prev, current)
-	suffix := current[prefixLen:]
-	if suffix == "" {
-		if len(current) == 0 {
-			return "", errors.New("mtime cannot be empty")
-		}
-		prefixLen = len(current) - 1
-		suffix = current[prefixLen:]
-	}
-	return strconv.Itoa(prefixLen) + ":" + suffix, nil
-}
-
-func encodePathToken(prev string, current string) string {
-	prefixLen := commonPrefixLen(prev, current)
-	suffix := current[prefixLen:]
-	return strconv.Itoa(prefixLen) + ":" + strconv.Itoa(len(suffix)) + ":" + suffix
-}
-
-func commonPrefixLen(a string, b string) int {
-	n := min(len(a), len(b))
-	for i := range n {
-		if a[i] != b[i] {
-			return i
-		}
-	}
-	return n
-}
 
 func resolveManifestEntryPath(manifest *Manifest, fileID uint64) (ManifestEntry, string, error) {
 	entry, ok := manifest.EntryByID(fileID)
@@ -2217,239 +2218,6 @@ func cloneTrailerMetadata(meta *FileTrailerMetadata) *FileTrailerMetadata {
 	return &cloned
 }
 
-func parseManifestHeader(line string) (string, string, string, int64, int, error) {
-	rest := strings.TrimPrefix(line, "FM/2 ")
-	sep := strings.IndexByte(rest, ' ')
-	if sep <= 0 || sep == len(rest)-1 {
-		return "", "", "", 0, 0, errors.New("invalid manifest header")
-	}
-	txferID := rest[:sep]
-	rootRaw := rest[sep+1:]
-	root, consumed, err := parseLenPrefixedPrefix(rootRaw)
-	if err != nil {
-		return "", "", "", 0, 0, fmt.Errorf("invalid manifest root token: %w", err)
-	}
-	optionsRaw := strings.TrimSpace(rootRaw[consumed:])
-	if optionsRaw == "" {
-		return "", "", "", 0, 0, errors.New("manifest header missing metadata options")
-	}
-	options := strings.Fields(optionsRaw)
-	var (
-		mode        string
-		linkMbps    int64
-		concurrency int
-		seenMode    bool
-		seenLink    bool
-		seenConc    bool
-	)
-	for _, option := range options {
-		key, value, ok := strings.Cut(option, "=")
-		if !ok {
-			return "", "", "", 0, 0, errors.New("invalid manifest header option")
-		}
-		switch key {
-		case "mode":
-			value = strings.ToLower(strings.TrimSpace(value))
-			if value != LoadStrategyFast && value != LoadStrategyGentle {
-				return "", "", "", 0, 0, errors.New("invalid manifest mode")
-			}
-			mode = value
-			seenMode = true
-		case "link-mbps":
-			linkMbps, err = strconv.ParseInt(strings.TrimSpace(value), 10, 64)
-			if err != nil || linkMbps < 0 {
-				return "", "", "", 0, 0, errors.New("invalid manifest link-mbps")
-			}
-			seenLink = true
-		case "concurrency":
-			concurrency, err = strconv.Atoi(strings.TrimSpace(value))
-			if err != nil || concurrency <= 0 {
-				return "", "", "", 0, 0, errors.New("invalid manifest concurrency")
-			}
-			seenConc = true
-		default:
-			return "", "", "", 0, 0, errors.New("unknown manifest header option")
-		}
-	}
-	if !seenMode || !seenLink || !seenConc {
-		return "", "", "", 0, 0, errors.New("manifest header missing required metadata")
-	}
-	return txferID, root, mode, linkMbps, concurrency, nil
-}
-
-func parseManifestEntry(line string, prevPath string, prevMtime string) (ManifestEntry, string, string, error) {
-	first := strings.IndexByte(line, ' ')
-	if first <= 0 {
-		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
-	}
-	second := strings.IndexByte(line[first+1:], ' ')
-	if second < 0 {
-		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
-	}
-	second += first + 1
-	third := strings.IndexByte(line[second+1:], ' ')
-	if third < 0 {
-		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
-	}
-	third += second + 1
-	fourth := strings.IndexByte(line[third+1:], ' ')
-	if fourth < 0 {
-		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
-	}
-	fourth += third + 1
-
-	idRaw := line[:first]
-	sizeRaw := line[first+1 : second]
-	mtimeToken := line[second+1 : third]
-	modeRaw := line[third+1 : fourth]
-	pathToken := line[fourth+1:]
-
-	id, err := strconv.ParseUint(idRaw, 10, 64)
-	if err != nil {
-		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest id: %w", err)
-	}
-	sizeU, err := strconv.ParseUint(sizeRaw, 10, 64)
-	if err != nil {
-		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest size: %w", err)
-	}
-	if sizeU > uint64(^uint64(0)>>1) {
-		return ManifestEntry{}, "", "", errors.New("manifest size overflows int64")
-	}
-
-	mtimeResolved, err := decodeMtimeToken(prevMtime, mtimeToken)
-	if err != nil {
-		return ManifestEntry{}, "", "", err
-	}
-	mtimeNanos, err := strconv.ParseUint(mtimeResolved, 10, 64)
-	if err != nil {
-		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest mtime value: %w", err)
-	}
-	if mtimeNanos > uint64(^uint64(0)>>1) {
-		return ManifestEntry{}, "", "", errors.New("manifest mtime overflows int64")
-	}
-	mode, err := parseManifestModeToken(modeRaw)
-	if err != nil {
-		return ManifestEntry{}, "", "", err
-	}
-
-	pathResolved, err := decodePathToken(prevPath, pathToken)
-	if err != nil {
-		return ManifestEntry{}, "", "", err
-	}
-	if strings.Contains(pathResolved, `\`) {
-		return ManifestEntry{}, "", "", errors.New("manifest path contains backslash")
-	}
-	if strings.HasPrefix(pathResolved, "/") {
-		return ManifestEntry{}, "", "", errors.New("manifest path must be relative")
-	}
-	cleanPath := filepath.Clean(filepath.FromSlash(pathResolved))
-	if cleanPath == "." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) || cleanPath == ".." {
-		return ManifestEntry{}, "", "", errors.New("manifest path traversal is not allowed")
-	}
-
-	entry := ManifestEntry{
-		ID:    id,
-		Size:  int64(sizeU),
-		Mtime: int64(mtimeNanos),
-		Mode:  mode,
-		Path:  pathResolved,
-	}
-	return entry, pathResolved, mtimeResolved, nil
-}
-
-func parseManifestModeToken(raw string) (os.FileMode, error) {
-	if raw == "" {
-		return 0, errors.New("manifest mode is required")
-	}
-	for _, ch := range raw {
-		if ch < '0' || ch > '7' {
-			return 0, errors.New("manifest mode must be octal")
-		}
-	}
-	v, err := strconv.ParseUint(raw, 8, 32)
-	if err != nil {
-		return 0, fmt.Errorf("invalid manifest mode: %w", err)
-	}
-	if v > 0o7777 {
-		return 0, errors.New("manifest mode must be <= 07777")
-	}
-	return os.FileMode(v), nil
-}
-
-
-func parseLenPrefixedPrefix(raw string) (string, int, error) {
-	sep := strings.IndexByte(raw, ':')
-	if sep <= 0 {
-		return "", 0, errors.New("invalid len-prefixed token")
-	}
-	n, err := strconv.Atoi(raw[:sep])
-	if err != nil || n < 0 {
-		return "", 0, errors.New("invalid len prefix")
-	}
-	start := sep + 1
-	end := start + n
-	if end > len(raw) {
-		return "", 0, errors.New("len prefix mismatch")
-	}
-	return raw[start:end], end, nil
-}
-
-func decodeMtimeToken(prev string, token string) (string, error) {
-	head, suffix, ok := strings.Cut(token, ":")
-	if !ok {
-		return "", errors.New("invalid mtime token")
-	}
-	prefixLen, err := strconv.Atoi(head)
-	if err != nil || prefixLen < 0 {
-		return "", errors.New("invalid mtime prefix length")
-	}
-	if prefixLen > len(prev) {
-		return "", errors.New("mtime prefix length exceeds previous value")
-	}
-	if suffix == "" {
-		return "", errors.New("empty mtime suffix")
-	}
-	for _, ch := range suffix {
-		if ch < '0' || ch > '9' {
-			return "", errors.New("mtime suffix must be decimal digits")
-		}
-	}
-	if prev == "" && prefixLen != 0 {
-		return "", errors.New("first mtime prefix length must be zero")
-	}
-	return prev[:prefixLen] + suffix, nil
-}
-
-func decodePathToken(prev string, token string) (string, error) {
-	first := strings.IndexByte(token, ':')
-	if first < 0 {
-		return "", errors.New("invalid path token")
-	}
-	second := strings.IndexByte(token[first+1:], ':')
-	if second < 0 {
-		return "", errors.New("invalid path token")
-	}
-	second += first + 1
-	prefixLen, err := strconv.Atoi(token[:first])
-	if err != nil || prefixLen < 0 {
-		return "", errors.New("invalid path prefix length")
-	}
-	if prefixLen > len(prev) {
-		return "", errors.New("path prefix length exceeds previous value")
-	}
-	suffixLen, err := strconv.Atoi(token[first+1 : second])
-	if err != nil || suffixLen < 0 {
-		return "", errors.New("invalid path suffix length")
-	}
-	suffix := token[second+1:]
-	if len(suffix) != suffixLen {
-		return "", errors.New("path suffix length mismatch")
-	}
-	if prev == "" && prefixLen != 0 {
-		return "", errors.New("first path prefix length must be zero")
-	}
-	return prev[:prefixLen] + suffix, nil
-}
 
 type fileStream struct {
 	respBody io.Closer

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -160,6 +160,12 @@ type Client struct {
 	// bufferPool caches reusable frame-read buffers keyed by bucketed size.
 	bufferPool sync.Map // map[int]*sync.Pool
 
+	// lineReaderPool caches reusable *bufio.Reader objects for protocol header reading.
+	// bufio.Reader is pooled (not its []byte) because Reset() reuses the internal allocation
+	// and its Read(p) passes directly to the socket when len(p) >= internal size, avoiding
+	// an extra copy that pooledLineReader would introduce for bulk payload reads.
+	lineReaderPool sync.Pool
+
 	// scratchBufferPool caches reusable temporary byte buffers.
 	scratchBufferPool sync.Pool
 }
@@ -385,6 +391,9 @@ const (
 	defaultClientFrameBufferBytes int = 8 * 1024 * 1024
 	minClientFrameReadBufferBytes int = 32 * 1024
 
+	// Line reader buffers used for protocol header reading (matches minClientFrameReadBufferBytes).
+	defaultClientLineReaderBytes int = 32 * 1024
+
 	// Scratch buffers used for request/response payloads (headers, manifests, etc.).
 	defaultClientScratchBufferBytes int = 64 * 1024
 	maxClientScratchBufferPoolBytes int = 16 * 1024 * 1024
@@ -420,6 +429,11 @@ func NewClient(fileAddr string, opts ...ClientOption) *Client {
 		opt.apply(c)
 	}
 	c.bufferPool = sync.Map{}
+	c.lineReaderPool = sync.Pool{
+		New: func() any {
+			return bufio.NewReaderSize(nil, defaultClientLineReaderBytes)
+		},
+	}
 	c.scratchBufferPool = sync.Pool{
 		New: func() any {
 			return bytes.NewBuffer(make([]byte, 0, defaultClientScratchBufferBytes))
@@ -752,7 +766,8 @@ func (c *Client) downloadManifestGroupSequential(
 		return nil, nil, nil, err
 	}
 	defer stream.Close()
-	br := bufio.NewReader(stream)
+	br := c.acquireLineReader(stream)
+	defer c.releaseLineReader(br)
 
 	results := make([]DownloadFileResponse, 0, len(plans))
 	pendingAcks := make([]AcknowledgeFileProgressRequest, 0, len(plans))
@@ -788,7 +803,6 @@ func (c *Client) downloadManifestGroupSequential(
 			return writer.Close()
 		}
 
-		fileHasher := xxh3.New128()
 		if plan.resumeFrom > 0 {
 			emitProgressUpdate(DownloadProgressUpdate{
 				TransferID:  req.Manifest.TransferID,
@@ -847,7 +861,7 @@ func (c *Client) downloadManifestGroupSequential(
 				return nil, nil, nil, fmt.Errorf("decode payload reader: %w", decodeErr)
 			}
 			frameStartOffset := offset
-			copyErr := copyStreamWithProgress(io.MultiWriter(writer, fileHasher, windowHasher), logicalReader, frameBuf, nil, func(written int64) error {
+			copyErr := copyStreamWithProgress(newParallelMultiWriter(writer, windowHasher), logicalReader, frameBuf, func(written int64) error {
 				emitProgressUpdate(DownloadProgressUpdate{
 					TransferID:  req.Manifest.TransferID,
 					FileID:      plan.entry.ID,
@@ -932,7 +946,7 @@ func (c *Client) downloadManifestGroupSequential(
 			return nil, nil, nil, fmt.Errorf("close output for file %d: %w", plan.entry.ID, err)
 		}
 
-		localHash := intencoding.FormatXXH128HashToken(fileHasher.Sum128())
+		localHash := windowHash
 		recvMS := time.Since(fileStart).Milliseconds()
 		deltaBytes := offset - plan.resumeFrom
 		pendingAcks = append(pendingAcks, AcknowledgeFileProgressRequest{
@@ -1360,7 +1374,7 @@ func (c *Client) downloadSplitWindow(
 	defer releaseFrameBuf()
 
 	windowHasher := xxh3.New128()
-	copyErr := copyStreamWithProgress(io.MultiWriter(writer, windowHasher), reader, frameBuf, nil, func(written int64) error {
+	copyErr := copyStreamWithProgress(newParallelMultiWriter(writer, windowHasher), reader, frameBuf, func(written int64) error {
 		emitProgressUpdate(DownloadProgressUpdate{
 			TransferID:  req.Manifest.TransferID,
 			FileID:      plan.entry.ID,
@@ -1834,18 +1848,47 @@ func mergeCompCounts(dst map[string]uint64, src map[string]uint64) {
 	}
 }
 
-func copyStreamWithProgress(dst io.Writer, src io.Reader, buf []byte, hash *xxh3.Hasher128, onWrite func(written int64) error) error {
+// parallelMultiWriter writes to primary in the calling goroutine and to each
+// secondary concurrently, joining all before returning from Write.
+// The buffer passed to Write must not be modified until Write returns.
+type parallelMultiWriter struct {
+	primary     io.Writer
+	secondaries []io.Writer
+}
+
+func newParallelMultiWriter(primary io.Writer, secondaries ...io.Writer) io.Writer {
+	if len(secondaries) == 0 {
+		return primary
+	}
+	return &parallelMultiWriter{primary: primary, secondaries: secondaries}
+}
+
+func (w *parallelMultiWriter) Write(p []byte) (int, error) {
+	errs := make([]chan error, len(w.secondaries))
+	for i, s := range w.secondaries {
+		ch := make(chan error, 1)
+		errs[i] = ch
+		go func(s io.Writer) {
+			_, err := s.Write(p)
+			ch <- err
+		}(s)
+	}
+	n, err := w.primary.Write(p)
+	for _, ch := range errs {
+		if sErr := <-ch; sErr != nil && err == nil {
+			err = sErr
+		}
+	}
+	return n, err
+}
+
+func copyStreamWithProgress(dst io.Writer, src io.Reader, buf []byte, onWrite func(written int64) error) error {
 	var written int64
 	for {
 		n, readErr := src.Read(buf)
 		if n > 0 {
 			if _, err := dst.Write(buf[:n]); err != nil {
 				return err
-			}
-			if hash != nil {
-				if _, err := hash.Write(buf[:n]); err != nil {
-					return err
-				}
 			}
 			written += int64(n)
 			if onWrite != nil {
@@ -1959,11 +2002,28 @@ func (c *Client) releaseScratchBuffer(buf *bytes.Buffer) {
 	c.scratchBufferPool.Put(buf)
 }
 
+func (c *Client) acquireLineReader(r io.Reader) *bufio.Reader {
+	raw := c.lineReaderPool.Get()
+	br := raw.(*bufio.Reader)
+	br.Reset(r)
+	return br
+}
+
+func (c *Client) releaseLineReader(br *bufio.Reader) {
+	br.Reset(nil) // release reference to the underlying reader
+	c.lineReaderPool.Put(br)
+}
+
 func parseManifest(raw []byte) (*Manifest, error) {
 	reader := bufio.NewReader(bytes.NewReader(raw))
 	manifest := &Manifest{}
+	// Pre-allocate based on newline count — an upper bound on entry count that
+	// avoids repeated growslice doublings (and the GC pauses they trigger) for
+	// large manifests.
+	capacityHint := bytes.Count(raw, []byte{'\n'})
+	manifest.Entries = make([]ManifestEntry, 0, capacityHint)
 	seenHeader := false
-	seenIDs := make(map[uint64]struct{})
+	seenIDs := make(map[uint64]struct{}, capacityHint)
 	var prevPath string
 	var prevMtime string
 	var lastID uint64

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -336,6 +336,96 @@ func (c *Client) fetchManifestTCP(ctx context.Context, request FetchManifestRequ
 	}
 }
 
+func (c *Client) syncManifestTCP(ctx context.Context, request SyncManifestRequest) (SyncManifestResponse, error) {
+	state, err := c.resolveTCPAuthState(request.AgePublicKey, request.AgeIdentity)
+	if err != nil {
+		return SyncManifestResponse{}, err
+	}
+	conn, err := c.dialTCP(ctx)
+	if err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("dial file listener: %w", err)
+	}
+	defer conn.Close()
+
+	if err := c.sendTCPAuth(conn, state); err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("send AUTH: %w", err)
+	}
+
+	// Send SYNC command line.
+	cmd := "SYNC " + makeLenToken(request.Directory) +
+		" mode=" + request.Mode +
+		" link-mbps=" + strconv.FormatInt(request.LinkMbps, 10) +
+		" concurrency=" + strconv.Itoa(request.Concurrency)
+	if err := c.sendTCPCommand(conn, state, cmd); err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("send SYNC: %w", err)
+	}
+
+	// Send old manifest body followed by blank line terminator.
+	oldManifestBytes, err := marshalManifest(request.OldManifest)
+	if err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("marshal old manifest: %w", err)
+	}
+	if _, err := conn.Write(oldManifestBytes); err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("write old manifest: %w", err)
+	}
+	if _, err := io.WriteString(conn, "\r\n"); err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("write manifest terminator: %w", err)
+	}
+
+	// Build ID→path index from the old manifest so we can resolve RM fileIDs.
+	oldByID := make(map[uint64]string, len(request.OldManifest.Entries))
+	for _, e := range request.OldManifest.Entries {
+		oldByID[e.ID] = e.Path
+	}
+
+	// Read response: FM/2 lines, then RM lines, then OK.
+	responseReader, err := c.responseReaderForTCP(conn, state)
+	if err != nil {
+		return SyncManifestResponse{}, fmt.Errorf("initialize SYNC response stream: %w", err)
+	}
+	br := bufio.NewReader(responseReader)
+
+	manifestBuf := c.acquireScratchBuffer(maxTCPLineBytes)
+	defer c.releaseScratchBuffer(manifestBuf)
+	var rmPaths []string
+
+	for {
+		line, err := readTCPLine(br, maxTCPLineBytes)
+		if err != nil {
+			return SyncManifestResponse{}, fmt.Errorf("read SYNC response: %w", err)
+		}
+		if _, ok := parseOKStatusLine(line); ok {
+			manifest, parseErr := parseManifest(manifestBuf.Bytes())
+			if parseErr != nil {
+				return SyncManifestResponse{}, parseErr
+			}
+			return SyncManifestResponse{
+				Manifest:     manifest,
+				RemovedPaths: rmPaths,
+			}, nil
+		}
+		if err := parseErrControlFrame(line); err != nil {
+			return SyncManifestResponse{}, err
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "RM ") {
+			fileID, parseErr := strconv.ParseUint(trimmed[3:], 10, 64)
+			if parseErr != nil {
+				return SyncManifestResponse{}, fmt.Errorf("parse RM line: %w", parseErr)
+			}
+			path, ok := oldByID[fileID]
+			if !ok {
+				return SyncManifestResponse{}, fmt.Errorf("RM fileID %d not in old manifest", fileID)
+			}
+			rmPaths = append(rmPaths, path)
+			continue
+		}
+		// FM/2 header or manifest entry line.
+		manifestBuf.WriteString(line)
+		manifestBuf.WriteByte('\n')
+	}
+}
+
 func (c *Client) fetchFileWindowTCP(
 	ctx context.Context,
 	txferID string,

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -22,9 +22,10 @@ import (
 const maxTCPLineBytes = 4 * 1024 * 1024
 
 type tcpAuthState struct {
-	publicKey       string
-	identity        string
-	hasAuth         bool
+	publicKey      string
+	identity       string
+	parsedIdentity age.Identity
+	hasAuth        bool
 	encryptCommands bool
 }
 
@@ -204,9 +205,11 @@ func (c *Client) resolveTCPAuthState(requestPub string, requestIdentity string) 
 		return tcpAuthState{}, errors.New("missing age identity for authenticated response")
 	}
 	if state.hasAuth {
-		if _, err := parseAgeIdentity(state.identity); err != nil {
+		parsed, err := parseAgeIdentity(state.identity)
+		if err != nil {
 			return tcpAuthState{}, err
 		}
+		state.parsedIdentity = parsed
 	}
 	if state.encryptCommands {
 		if _, err := age.ParseX25519Recipient(serverPub); err != nil {
@@ -265,10 +268,7 @@ func (c *Client) responseReaderForTCP(conn net.Conn, state tcpAuthState) (io.Rea
 	if !state.hasAuth {
 		return conn, nil
 	}
-	identity, err := parseAgeIdentity(state.identity)
-	if err != nil {
-		return nil, err
-	}
+	identity := state.parsedIdentity
 	if identity == nil {
 		return nil, errors.New("missing age identity for encrypted response")
 	}

--- a/server/internal/cmd/filexfercli/cli.go
+++ b/server/internal/cmd/filexfercli/cli.go
@@ -741,15 +741,22 @@ func printStartFileSummary(stdout io.Writer, fileID uint64, path string, meta Fi
 	default:
 		checksum = "checksum=[-]"
 	}
-	fmt.Fprintf(
-		stdout,
-		"start-file: fd=%d path=%s %s comp=%s rate=%s\n",
-		fileID,
-		path,
-		checksum,
-		compSummary,
-		encoding.HumanRate(speed),
-	)
+	// Build the full line before writing to avoid multiple Write calls (and lock
+	// acquisitions) on the synchronized stdout writer.
+	var sb strings.Builder
+	sb.Grow(128)
+	sb.WriteString("start-file: fd=")
+	sb.WriteString(strconv.FormatUint(fileID, 10))
+	sb.WriteString(" path=")
+	sb.WriteString(path)
+	sb.WriteByte(' ')
+	sb.WriteString(checksum)
+	sb.WriteString(" comp=")
+	sb.WriteString(compSummary)
+	sb.WriteString(" rate=")
+	sb.WriteString(encoding.HumanRate(speed))
+	sb.WriteByte('\n')
+	io.WriteString(stdout, sb.String())
 }
 
 func startVerboseStatusPolling(txferID string, client *Client, stderr io.Writer) func() {

--- a/server/internal/cmd/filexfercli/cli.go
+++ b/server/internal/cmd/filexfercli/cli.go
@@ -85,6 +85,8 @@ func RunCLI(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runStatusCLI(serverURL, cmdArgs, stdout, stderr)
 	case "get":
 		return runGetCLI(serverURL, cmdArgs, stdout, stderr)
+	case "sync":
+		return runSyncCLI(serverURL, cmdArgs, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown cli command: %s\n", cmd)
 		printCLIUsage(stderr)
@@ -111,6 +113,7 @@ func printCLIUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage:")
 	fmt.Fprintln(w, "  pinch cli <file-listener> transfer -s <abs> [--source-directory <abs>] [-o <manifest-path>] [--encrypt age] [--load-strategy fast|gentle] [--probe-bytes <size>] [-v|--verbose] [--max-manifest-chunk-size N]")
 	fmt.Fprintln(w, "  pinch cli <file-listener> start [--tid <id>] [--manifest <path>] [--out-root <dir>] [--encrypt age] [--concurrency N] [-a|--ack-every <size>] [--batch-size <size>] [--no-sync] [-v|--verbose]")
+	fmt.Fprintln(w, "  pinch cli <file-listener> sync -s <abs> --manifest <path> [--out-root <dir>] [-o <manifest-out>] [-y|--yes] [--encrypt age] [--comp adapt|none|lz4|zstd] [--concurrency N] [-a|--ack-every <size>] [--batch-size <size>] [--no-sync] [-v|--verbose]")
 	fmt.Fprintln(w, "  pinch cli <file-listener> status --tid <id>")
 	fmt.Fprintln(w, "  pinch cli <file-listener> get [--tid <id>] --fd <uint64> [--manifest <path>] [--out-root <dir>] [-o <path|->] [--encrypt age] [--load-strategy fast|gentle] [-a|--ack-every <size>] [--batch-size <size>] [--no-sync] [-v|--verbose]")
 }
@@ -154,8 +157,12 @@ func resolveComp(raw string) (string, error) {
 }
 
 func runTransferCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
-	fs := flag.NewFlagSet("transfer", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	cf := newCLIFlags("transfer")
+	cf.SetOutput(stderr)
+	cf.fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: pinch cli <file-listener> transfer -s <dir> [-o <manifest>] [--encrypt age] [--load-strategy fast|gentle] [-v]")
+		cf.PrintDefaults(stderr)
+	}
 	var sourceDir string
 	var manifestOut string
 	var encryptMode string
@@ -163,17 +170,15 @@ func runTransferCLI(serverURL string, args []string, stdout io.Writer, stderr io
 	var probeBytesRaw string
 	var verbose bool
 	var maxChunk int
-	fs.StringVar(&sourceDir, "s", "", "absolute source directory to transfer")
-	fs.StringVar(&sourceDir, "source-directory", "", "absolute source directory to transfer")
-	fs.StringVar(&manifestOut, "o", "", "output path for saved manifest")
-	fs.StringVar(&encryptMode, "encrypt", "", "response encryption mode (supported: age)")
-	fs.StringVar(&loadStrategyRaw, "load-strategy", LoadStrategyFast, "server load strategy (fast|gentle)")
+	cf.StringVar(&sourceDir, "s", "source-directory", "", "absolute source directory to transfer")
+	cf.StringVar(&manifestOut, "o", "", "", "output path for saved manifest")
+	cf.StringVar(&encryptMode, "", "encrypt", "", "response encryption mode (supported: age)")
+	cf.StringVar(&loadStrategyRaw, "", "load-strategy", LoadStrategyFast, "server load strategy (fast|gentle)")
 	probeBytesRaw = encoding.HumanBytes(defaultCLIProbeBytes)
-	fs.StringVar(&probeBytesRaw, "probe-bytes", probeBytesRaw, "probe payload size for transfer metadata")
-	fs.BoolVar(&verbose, "v", false, "disable front-coding")
-	fs.BoolVar(&verbose, "verbose", false, "disable front-coding")
-	fs.IntVar(&maxChunk, "max-manifest-chunk-size", 0, "max chunk bytes for manifest stream")
-	if err := fs.Parse(args); err != nil {
+	cf.StringVar(&probeBytesRaw, "", "probe-bytes", probeBytesRaw, "probe payload size for transfer metadata")
+	cf.BoolVar(&verbose, "v", "verbose", false, "disable front-coding")
+	cf.IntVar(&maxChunk, "", "max-manifest-chunk-size", 0, "max chunk bytes for manifest stream")
+	if err := cf.Parse(args); err != nil {
 		return 2
 	}
 	if sourceDir == "" {
@@ -285,11 +290,15 @@ func runTransferCLI(serverURL string, args []string, stdout io.Writer, stderr io
 }
 
 func runStatusCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
-	fs := flag.NewFlagSet("status", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	cf := newCLIFlags("status")
+	cf.SetOutput(stderr)
+	cf.fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: pinch cli <file-listener> status --tid <id>")
+		cf.PrintDefaults(stderr)
+	}
 	var txferID string
-	fs.StringVar(&txferID, "tid", "", "transfer id")
-	if err := fs.Parse(args); err != nil {
+	cf.StringVar(&txferID, "", "tid", "", "transfer id")
+	if err := cf.Parse(args); err != nil {
 		return 2
 	}
 	if txferID == "" {
@@ -321,8 +330,12 @@ func runStatusCLI(serverURL string, args []string, stdout io.Writer, stderr io.W
 }
 
 func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
-	fs := flag.NewFlagSet("get", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	cf := newCLIFlags("get")
+	cf.SetOutput(stderr)
+	cf.fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: pinch cli <file-listener> get [--tid <id>] --fd <uint64> [--manifest <path>] [--out-root <dir>] [-o <path|->] [--encrypt age] [-a <size>] [-b <size>] [-v]")
+		cf.PrintDefaults(stderr)
+	}
 	var txferID string
 	var manifestPath string
 	var fileIDRaw string
@@ -336,24 +349,21 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	var noSync bool
 	var verbose bool
 	var traceFile string
-	fs.StringVar(&txferID, "tid", "", "transfer id")
-	fs.StringVar(&manifestPath, "manifest", "", "path to manifest file (default: <tid>.fm2)")
-	fs.StringVar(&fileIDRaw, "fd", "", "file id to download")
-	fs.StringVar(&outRoot, "out-root", ".", "output root")
-	fs.StringVar(&outFile, "o", "", "output file path, or '-' for stdout")
-	fs.StringVar(&encryptMode, "encrypt", "", "response encryption mode (supported: age)")
-	fs.StringVar(&loadStrategyRaw, "load-strategy", LoadStrategyFast, "server load strategy (fast|gentle)")
-	fs.StringVar(&compRaw, "comp", "", "compression algorithm: adapt|none|lz4|zstd (default: adapt)")
-	fs.BoolVar(&verbose, "v", false, "verbose progress output")
-	fs.BoolVar(&verbose, "verbose", false, "verbose progress output")
+	cf.StringVar(&txferID, "", "tid", "", "transfer id")
+	cf.StringVar(&manifestPath, "", "manifest", "", "path to manifest file (default: <tid>.fm2)")
+	cf.StringVar(&fileIDRaw, "", "fd", "", "file id to download")
+	cf.StringVar(&outRoot, "", "out-root", ".", "output root")
+	cf.StringVar(&outFile, "o", "", "", "output file path, or '-' for stdout")
+	cf.StringVar(&encryptMode, "", "encrypt", "", "response encryption mode (supported: age)")
+	cf.StringVar(&loadStrategyRaw, "", "load-strategy", LoadStrategyFast, "server load strategy (fast|gentle)")
+	cf.StringVar(&compRaw, "", "comp", "", "compression algorithm: adapt|none|lz4|zstd (default: adapt)")
+	cf.BoolVar(&verbose, "v", "verbose", false, "verbose progress output")
 	ackEveryRaw = encoding.HumanBytes(defaultCLIAckEveryBytes)
-	fs.StringVar(&ackEveryRaw, "a", ackEveryRaw, "bytes between progress acks")
-	fs.StringVar(&ackEveryRaw, "ack-every", ackEveryRaw, "bytes between progress acks")
-	fs.StringVar(&batchSizeRaw, "b", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
-	fs.StringVar(&batchSizeRaw, "batch-size", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
-	fs.BoolVar(&noSync, "no-sync", false, "ack without disk sync")
-	fs.StringVar(&traceFile, "trace", "", "write runtime/trace output to this file")
-	if err := fs.Parse(args); err != nil {
+	cf.StringVar(&ackEveryRaw, "a", "ack-every", ackEveryRaw, "bytes between progress acks")
+	cf.StringVar(&batchSizeRaw, "b", "batch-size", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
+	cf.BoolVar(&noSync, "", "no-sync", false, "ack without disk sync")
+	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	if err := cf.Parse(args); err != nil {
 		return 2
 	}
 	stopTracing := startTracing(traceFile, stderr)
@@ -485,13 +495,378 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	return 0
 }
 
+func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
+	outputMu := &sync.Mutex{}
+	stdout = &synchronizedWriter{mu: outputMu, w: stdout}
+	stderr = &synchronizedWriter{mu: outputMu, w: stderr}
+
+	cf := newCLIFlags("sync")
+	cf.SetOutput(stderr)
+	cf.fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: pinch cli <file-listener> sync -s <dir> --manifest <path> [--out-root <dir>] [-o <manifest-out>] [-y] [--encrypt age] [--comp adapt|none|lz4|zstd] [--concurrency N] [-a <size>] [-b <size>] [-v]")
+		cf.PrintDefaults(stderr)
+	}
+	var sourceDir string
+	var manifestPath string
+	var manifestOut string
+	var outRoot string
+	var encryptMode string
+	var concurrency int
+	var ackEveryRaw string
+	var batchSizeRaw string
+	var compRaw string
+	var noSync bool
+	var verbose bool
+	var yes bool
+	var probeBytesRaw string
+	var traceFile string
+	cf.StringVar(&sourceDir, "s", "source-directory", "", "absolute source directory on server")
+	cf.StringVar(&manifestPath, "", "manifest", "", "path to existing manifest file (required)")
+	cf.StringVar(&manifestOut, "o", "", "", "output path for updated manifest (default: overwrite --manifest)")
+	cf.StringVar(&outRoot, "", "out-root", ".", "local output root directory")
+	cf.StringVar(&encryptMode, "", "encrypt", "", "response encryption mode (supported: age)")
+	cf.StringVar(&compRaw, "", "comp", "", "compression algorithm: adapt|none|lz4|zstd (default: adapt)")
+	cf.IntVar(&concurrency, "", "concurrency", 0, "parallel download workers (0=manifest default)")
+	cf.BoolVar(&verbose, "v", "verbose", false, "verbose progress output")
+	cf.BoolVar(&yes, "y", "yes", false, "skip confirmation prompt")
+	ackEveryRaw = encoding.HumanBytes(defaultCLIAckEveryBytes)
+	cf.StringVar(&ackEveryRaw, "a", "ack-every", ackEveryRaw, "bytes between progress acks")
+	cf.StringVar(&batchSizeRaw, "b", "batch-size", ackEveryRaw, "parallel batch size")
+	cf.BoolVar(&noSync, "", "no-sync", false, "ack without fdatasync")
+	probeBytesRaw = encoding.HumanBytes(defaultCLIProbeBytes)
+	cf.StringVar(&probeBytesRaw, "", "probe-bytes", probeBytesRaw, "probe payload size")
+	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	if err := cf.Parse(args); err != nil {
+		return 2
+	}
+	stopTracing := startTracing(traceFile, stderr)
+	defer stopTracing()
+	if sourceDir == "" {
+		fmt.Fprintln(stderr, "sync requires --source-directory (or -s)")
+		return 2
+	}
+	if manifestPath == "" {
+		fmt.Fprintln(stderr, "sync requires --manifest")
+		return 2
+	}
+	if manifestOut == "" {
+		manifestOut = manifestPath
+	}
+	ackEvery, err := encoding.ParseByteSize(ackEveryRaw)
+	if err != nil || ackEvery <= 0 {
+		fmt.Fprintf(stderr, "invalid --ack-every: %v\n", err)
+		return 2
+	}
+	batchSize, err := encoding.ParseByteSize(batchSizeRaw)
+	if err != nil || batchSize <= 0 {
+		fmt.Fprintf(stderr, "invalid --batch-size: %v\n", err)
+		return 2
+	}
+	probeBytes, err := encoding.ParseByteSize(probeBytesRaw)
+	if err != nil || probeBytes <= 0 {
+		fmt.Fprintf(stderr, "invalid --probe-bytes: %v\n", err)
+		return 2
+	}
+	agePublicKey, ageIdentity, err := resolveEncryptionOptions(encryptMode)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid --encrypt: %v\n", err)
+		return 2
+	}
+	comp, err := resolveComp(compRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid --comp: %v\n", err)
+		return 2
+	}
+	concurrencyExplicit := false
+	cf.Visit(func(f *flag.Flag) {
+		if f.Name == "concurrency" {
+			concurrencyExplicit = true
+		}
+	})
+	if concurrencyExplicit && concurrency <= 0 {
+		fmt.Fprintln(stderr, "--concurrency must be > 0")
+		return 2
+	}
+
+	// Load old manifest and progress.
+	oldManifest, err := LoadManifest(manifestPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load manifest failed: %v\n", err)
+		return 1
+	}
+	loadStrategy, err := resolveLoadStrategy(oldManifest.Mode)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid manifest mode: %v\n", err)
+		return 1
+	}
+	progressPath := manifestPath + ".progress"
+	progressState, err := loadProgressState(progressPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load progress failed: %v\n", err)
+		return 1
+	}
+	applyProgressStateToManifest(oldManifest, progressState)
+
+	// Probe link bandwidth.
+	client := NewClient(serverURL, WithLoadStrategy(loadStrategy), WithComp(comp))
+	probeResult, err := client.ProbeLink(context.Background(), ProbeRequest{
+		Samples:      3,
+		ProbeBytes:   probeBytes,
+		LoadStrategy: loadStrategy,
+		AgePublicKey: agePublicKey,
+		AgeIdentity:  ageIdentity,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "probe failed: %v\n", err)
+		return 1
+	}
+
+	// SYNC: send old manifest, receive new manifest + removed paths.
+	syncResp, err := client.SyncManifest(context.Background(), SyncManifestRequest{
+		Directory:    sourceDir,
+		OldManifest:  oldManifest,
+		Mode:         loadStrategy,
+		LinkMbps:     probeResult.LinkMbps,
+		Concurrency:  probeResult.SuggestedConcurrency,
+		AgePublicKey: agePublicKey,
+		AgeIdentity:  ageIdentity,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "sync failed: %v\n", err)
+		return 1
+	}
+	newManifest := syncResp.Manifest
+
+	// Compute delta: new, stale, unchanged, removed.
+	oldByPath := make(map[string]ManifestEntry, len(oldManifest.Entries))
+	for _, e := range oldManifest.Entries {
+		oldByPath[e.Path] = e
+	}
+	var newFiles, staleFiles, unchangedFiles []ManifestEntry
+	var newBytes, staleBytes int64
+	for _, entry := range newManifest.Entries {
+		if old, ok := oldByPath[entry.Path]; ok {
+			if old.Size == entry.Size && old.Mtime == entry.Mtime && old.Mode == entry.Mode {
+				// Unchanged — carry over progress.
+				entry.Progress = old.Progress
+				unchangedFiles = append(unchangedFiles, entry)
+			} else {
+				// Stale — reset progress.
+				staleFiles = append(staleFiles, entry)
+				staleBytes += entry.Size
+			}
+		} else {
+			newFiles = append(newFiles, entry)
+			newBytes += entry.Size
+		}
+	}
+	rmPaths := syncResp.RemovedPaths
+
+	fmt.Fprintf(stdout,
+		"sync-delta: new=%d (%s) stale=%d (%s) unchanged=%d rm=%d link=%dMbps concurrency=%d\n",
+		len(newFiles), encoding.HumanBytes(newBytes),
+		len(staleFiles), encoding.HumanBytes(staleBytes),
+		len(unchangedFiles),
+		len(rmPaths),
+		probeResult.LinkMbps,
+		probeResult.SuggestedConcurrency,
+	)
+
+	if len(newFiles) == 0 && len(staleFiles) == 0 && len(rmPaths) == 0 {
+		fmt.Fprintln(stdout, "sync: nothing to do")
+		return 0
+	}
+
+	// Prompt for confirmation if interactive.
+	if !yes {
+		stat, _ := os.Stdin.Stat()
+		isTerminal := stat != nil && (stat.Mode()&os.ModeCharDevice) != 0
+		if isTerminal {
+			fmt.Fprintf(stderr, "proceed? [y/N]: ")
+			scanner := bufio.NewScanner(os.Stdin)
+			if !scanner.Scan() || !strings.HasPrefix(strings.ToLower(strings.TrimSpace(scanner.Text())), "y") {
+				fmt.Fprintln(stderr, "aborted")
+				return 0
+			}
+		}
+	}
+
+	// Build merged manifest with new entries, carry progress for unchanged.
+	mergedManifest := &Manifest{
+		TransferID:  newManifest.TransferID,
+		Root:        newManifest.Root,
+		Mode:        newManifest.Mode,
+		LinkMbps:    newManifest.LinkMbps,
+		Concurrency: newManifest.Concurrency,
+		Entries:     newManifest.Entries,
+	}
+	// Apply carried progress to merged manifest entries.
+	for _, uf := range unchangedFiles {
+		for i := range mergedManifest.Entries {
+			if mergedManifest.Entries[i].ID == uf.ID {
+				mergedManifest.Entries[i].Progress = uf.Progress
+				break
+			}
+		}
+	}
+
+	// Save merged manifest.
+	if err := SaveManifest(manifestOut, mergedManifest); err != nil {
+		fmt.Fprintf(stderr, "save manifest failed: %v\n", err)
+		return 1
+	}
+
+	// Delete local files for removed paths.
+	for _, rmPath := range rmPaths {
+		localPath := filepath.Join(outRoot, filepath.FromSlash(rmPath))
+		if err := os.Remove(localPath); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "sync: rm %s: %v\n", localPath, err)
+		}
+	}
+	// Truncate local files for stale entries.
+	for _, entry := range staleFiles {
+		localPath := filepath.Join(outRoot, filepath.FromSlash(entry.Path))
+		if err := os.Truncate(localPath, 0); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "sync: truncate %s: %v\n", localPath, err)
+		}
+	}
+
+	// Build progress state for merged manifest.
+	mergedProgress := make(map[uint64]ManifestProgress, len(mergedManifest.Entries))
+	for _, e := range mergedManifest.Entries {
+		if e.Progress.AckBytes > 0 || e.Progress.MetadataDone {
+			mergedProgress[e.ID] = e.Progress
+		}
+	}
+
+	// Download pending entries (new + stale).
+	pendingEntries := make([]ManifestEntry, 0, len(newFiles)+len(staleFiles))
+	for _, entry := range mergedManifest.Entries {
+		if entry.Progress.AckBytes >= entry.Size && entry.Progress.MetadataDone {
+			continue
+		}
+		pendingEntries = append(pendingEntries, entry)
+	}
+
+	if len(pendingEntries) == 0 {
+		fmt.Fprintln(stdout, "sync: no downloads needed")
+		return 0
+	}
+
+	effectiveConcurrency := mergedManifest.Concurrency
+	if concurrencyExplicit {
+		effectiveConcurrency = concurrency
+	}
+
+	progressUpdates := make(chan DownloadProgressUpdate, 1024)
+	var onProgressUpdate func(DownloadProgressUpdate)
+	if verbose {
+		progressReporter := newVerboseProgressReporter(stderr)
+		onProgressUpdate = progressReporter.ReportUpdate
+	}
+	mergedProgressPath := manifestOut + ".progress"
+	forwardProgress := func(update DownloadProgressUpdate) {
+		applyProgressUpdateToManifest(mergedManifest, update)
+		if onProgressUpdate != nil {
+			onProgressUpdate(update)
+		}
+	}
+	stopProgress, markMetadataDonePersisted := startProgressWriter(mergedProgressPath, mergedProgress, progressUpdates, forwardProgress, stderr)
+	markMetadataDone := func(fileID uint64) {
+		markManifestEntryMetadataDone(mergedManifest, fileID)
+		markMetadataDonePersisted(fileID)
+	}
+	defer stopProgress()
+
+	startAll := time.Now()
+	var completed int64
+	var totalTransferred int64
+	var failures []error
+	var failuresMu sync.Mutex
+	recordFailure := func(err error) {
+		if err == nil {
+			return
+		}
+		failuresMu.Lock()
+		failures = append(failures, err)
+		failuresMu.Unlock()
+	}
+
+	startResp, err := client.StartFromManifest(context.Background(), StartFromManifestRequest{
+		Manifest: mergedManifest,
+		Entries:  pendingEntries,
+		OutputWriter: func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
+			destPath := resolveDownloadDestinationPath(entry, outRoot, "")
+			return openDownloadOutput(entry, offset, destPath, nil, noSync)
+		},
+		AgePublicKey:    agePublicKey,
+		AgeIdentity:     ageIdentity,
+		Concurrency:     effectiveConcurrency,
+		BatchMaxBytes:   batchSize,
+		ProgressUpdates: progressUpdates,
+		OnFileDone: func(evt StartFileDoneEvent) {
+			entry, ok := mergedManifest.EntryByID(evt.File.Meta.FileID)
+			if !ok {
+				recordFailure(fmt.Errorf("id=%d metadata apply failed: file id not in manifest", evt.File.Meta.FileID))
+				return
+			}
+			destPath := resolveDownloadDestinationPath(entry, outRoot, "")
+			if err := applyDownloadedTrailerMetadata(destPath, evt.File.Meta.TrailerMetadata); err != nil {
+				recordFailure(fmt.Errorf("id=%d metadata apply failed: %w", evt.File.Meta.FileID, err))
+				return
+			}
+			markMetadataDone(evt.File.Meta.FileID)
+			printStartFileSummary(stdout, evt.File.Meta.FileID, destPath, evt.File.Meta, evt.File.LocalFileHash, evt.File.WindowChecksumPassed, evt.File.WindowChecksumTotal, evt.Elapsed)
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "sync download failed: %v\n", err)
+		return 1
+	}
+	completed += int64(startResp.Downloaded)
+	totalTransferred += startResp.TransferredBytes
+	for _, startErr := range startResp.Errors {
+		recordFailure(startErr)
+	}
+
+	failuresMu.Lock()
+	finalFailures := append([]error(nil), failures...)
+	failuresMu.Unlock()
+	for _, err := range finalFailures {
+		fmt.Fprintf(stderr, "sync error: %v\n", err)
+	}
+
+	elapsedAll := time.Since(startAll)
+	overallSpeed := 0.0
+	if elapsedAll > 0 {
+		overallSpeed = float64(totalTransferred) / elapsedAll.Seconds()
+	}
+	fmt.Fprintf(stdout,
+		"sync complete: tid=%s downloaded=%d failed=%d transferred=%s speed=%s elapsed=%s\n",
+		mergedManifest.TransferID,
+		completed,
+		len(finalFailures),
+		encoding.HumanBytes(totalTransferred),
+		encoding.HumanRate(overallSpeed),
+		elapsedAll.Round(time.Millisecond),
+	)
+	if len(finalFailures) > 0 {
+		return 1
+	}
+	return 0
+}
+
 func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
 	outputMu := &sync.Mutex{}
 	stdout = &synchronizedWriter{mu: outputMu, w: stdout}
 	stderr = &synchronizedWriter{mu: outputMu, w: stderr}
 
-	fs := flag.NewFlagSet("start", flag.ContinueOnError)
-	fs.SetOutput(stderr)
+	cf := newCLIFlags("start")
+	cf.SetOutput(stderr)
+	cf.fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: pinch cli <file-listener> start [--tid <id>] [--manifest <path>] [--out-root <dir>] [--encrypt age] [--concurrency N] [-a <size>] [-b <size>] [--no-sync] [-v]")
+		cf.PrintDefaults(stderr)
+	}
 	var txferID string
 	var manifestPath string
 	var outRoot string
@@ -502,29 +877,26 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 	var compRaw string
 	var noSync bool
 	var verbose bool
-	fs.StringVar(&txferID, "tid", "", "transfer id")
-	fs.StringVar(&manifestPath, "manifest", "", "path to manifest file (default: <tid>.fm2)")
-	fs.StringVar(&outRoot, "out-root", ".", "output root")
-	fs.StringVar(&encryptMode, "encrypt", "", "response encryption mode (supported: age)")
-	fs.BoolVar(&verbose, "v", false, "verbose progress output")
-	fs.BoolVar(&verbose, "verbose", false, "verbose progress output")
-	fs.IntVar(&concurrency, "concurrency", 0, "parallel download workers (0=manifest default)")
+	cf.StringVar(&txferID, "", "tid", "", "transfer id")
+	cf.StringVar(&manifestPath, "", "manifest", "", "path to manifest file (default: <tid>.fm2)")
+	cf.StringVar(&outRoot, "", "out-root", ".", "output root")
+	cf.StringVar(&encryptMode, "", "encrypt", "", "response encryption mode (supported: age)")
+	cf.BoolVar(&verbose, "v", "verbose", false, "verbose progress output")
+	cf.IntVar(&concurrency, "", "concurrency", 0, "parallel download workers (0=manifest default)")
 	ackEveryRaw = encoding.HumanBytes(defaultCLIAckEveryBytes)
-	fs.StringVar(&ackEveryRaw, "a", ackEveryRaw, "bytes between progress acks")
-	fs.StringVar(&ackEveryRaw, "ack-every", ackEveryRaw, "bytes between progress acks")
-	fs.StringVar(&batchSizeRaw, "b", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
-	fs.StringVar(&batchSizeRaw, "batch-size", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
-	fs.StringVar(&compRaw, "comp", "", "compression algorithm: adapt|none|lz4|zstd (default: adapt)")
-	fs.BoolVar(&noSync, "no-sync", false, "ack without fdatasync")
+	cf.StringVar(&ackEveryRaw, "a", "ack-every", ackEveryRaw, "bytes between progress acks")
+	cf.StringVar(&batchSizeRaw, "b", "batch-size", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
+	cf.StringVar(&compRaw, "", "comp", "", "compression algorithm: adapt|none|lz4|zstd (default: adapt)")
+	cf.BoolVar(&noSync, "", "no-sync", false, "ack without fdatasync")
 	var traceFile string
-	fs.StringVar(&traceFile, "trace", "", "write runtime/trace output to this file")
-	if err := fs.Parse(args); err != nil {
+	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	if err := cf.Parse(args); err != nil {
 		return 2
 	}
 	stopTracing := startTracing(traceFile, stderr)
 	defer stopTracing()
 	concurrencyExplicit := false
-	fs.Visit(func(f *flag.Flag) {
+	cf.Visit(func(f *flag.Flag) {
 		if f.Name == "concurrency" {
 			concurrencyExplicit = true
 		}

--- a/server/internal/cmd/filexfercli/flags.go
+++ b/server/internal/cmd/filexfercli/flags.go
@@ -1,0 +1,114 @@
+package filexfercli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// flagEntry records one option for combined help rendering.
+type flagEntry struct {
+	short string // "s", "v" — empty for long-only flags
+	long  string // "source-directory", "verbose" — empty for short-only flags
+	typ   string // "string", "int" — empty for bool flags
+	usage string
+}
+
+// cliFlags wraps flag.FlagSet and tracks short/long pairs so they can be
+// printed combined ("-s, --source-directory string   description") rather than
+// as two separate lines.
+type cliFlags struct {
+	fs    *flag.FlagSet
+	pairs []flagEntry
+}
+
+func newCLIFlags(name string) *cliFlags {
+	return &cliFlags{fs: flag.NewFlagSet(name, flag.ContinueOnError)}
+}
+
+func (c *cliFlags) SetOutput(w io.Writer)                       { c.fs.SetOutput(w) }
+func (c *cliFlags) Parse(args []string) error                   { return c.fs.Parse(args) }
+func (c *cliFlags) Arg(i int) string                            { return c.fs.Arg(i) }
+func (c *cliFlags) Args() []string                              { return c.fs.Args() }
+func (c *cliFlags) NArg() int                                   { return c.fs.NArg() }
+func (c *cliFlags) Visit(fn func(*flag.Flag))                   { c.fs.Visit(fn) }
+
+// StringVar registers a string flag. Pass short="" for long-only, long="" for short-only.
+func (c *cliFlags) StringVar(p *string, short, long, defVal, usage string) {
+	if short != "" {
+		c.fs.StringVar(p, short, defVal, usage)
+	}
+	if long != "" {
+		c.fs.StringVar(p, long, defVal, usage)
+	}
+	c.pairs = append(c.pairs, flagEntry{short: short, long: long, typ: "string", usage: usage})
+}
+
+// BoolVar registers a bool flag. Pass short="" for long-only, long="" for short-only.
+func (c *cliFlags) BoolVar(p *bool, short, long string, defVal bool, usage string) {
+	if short != "" {
+		c.fs.BoolVar(p, short, defVal, usage)
+	}
+	if long != "" {
+		c.fs.BoolVar(p, long, defVal, usage)
+	}
+	c.pairs = append(c.pairs, flagEntry{short: short, long: long, typ: "", usage: usage})
+}
+
+// IntVar registers an int flag. Pass short="" for long-only, long="" for short-only.
+func (c *cliFlags) IntVar(p *int, short, long string, defVal int, usage string) {
+	if short != "" {
+		c.fs.IntVar(p, short, defVal, usage)
+	}
+	if long != "" {
+		c.fs.IntVar(p, long, defVal, usage)
+	}
+	c.pairs = append(c.pairs, flagEntry{short: short, long: long, typ: "int", usage: usage})
+}
+
+// leftCol returns the formatted left column for a flag entry:
+//
+//	"-s, --source-directory string"   (short + long)
+//	"    --manifest string"           (long-only)
+//	"-o string"                       (short-only)
+//	"-v, --verbose"                   (bool, short + long)
+func (e flagEntry) leftCol() string {
+	var b strings.Builder
+	switch {
+	case e.short != "" && e.long != "":
+		b.WriteString("-")
+		b.WriteString(e.short)
+		b.WriteString(", --")
+		b.WriteString(e.long)
+	case e.long != "":
+		b.WriteString("    --")
+		b.WriteString(e.long)
+	default:
+		b.WriteString("-")
+		b.WriteString(e.short)
+	}
+	if e.typ != "" {
+		b.WriteString(" ")
+		b.WriteString(e.typ)
+	}
+	return b.String()
+}
+
+// PrintDefaults writes age-style combined option help to w.
+func (c *cliFlags) PrintDefaults(w io.Writer) {
+	if len(c.pairs) == 0 {
+		return
+	}
+	// Compute max left-column width for alignment.
+	maxW := 0
+	for _, e := range c.pairs {
+		if n := len(e.leftCol()); n > maxW {
+			maxW = n
+		}
+	}
+	fmt.Fprintln(w, "Options:")
+	for _, e := range c.pairs {
+		fmt.Fprintf(w, "  %-*s  %s\n", maxW, e.leftCol(), e.usage)
+	}
+}

--- a/server/internal/filexfer/encoding/codec.go
+++ b/server/internal/filexfer/encoding/codec.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
@@ -19,12 +20,15 @@ const (
 	EncodingLz4      = "lz4"
 )
 
+const defaultZstdFrameSize = 8 * 1024 * 1024
+
 type zstdMaxEncodedSizeCache struct {
-	once sync.Once
-	mu   sync.Mutex
-	enc  *zstd.Encoder
-	err  error
-	size map[int]int
+	once           sync.Once
+	mu             sync.RWMutex
+	enc            *zstd.Encoder
+	err            error
+	size           map[int]int
+	defaultMaxSize atomic.Int64
 }
 
 var zstdMaxSizer zstdMaxEncodedSizeCache
@@ -36,12 +40,29 @@ func (c *zstdMaxEncodedSizeCache) maxEncodedSize(n int) (int, error) {
 		c.enc, c.err = zstd.NewWriter(io.Discard)
 		if c.err == nil {
 			c.size = make(map[int]int)
+			defaultMax := c.enc.MaxEncodedSize(defaultZstdFrameSize)
+			c.defaultMaxSize.Store(int64(defaultMax))
+			c.size[defaultZstdFrameSize] = defaultMax
 		}
 	})
 	if c.err != nil {
 		return 0, c.err
 	}
 
+	// Lock-free fast path for the default frame size.
+	if n == defaultZstdFrameSize {
+		return int(c.defaultMaxSize.Load()), nil
+	}
+
+	// Read-lock fast path for other cached sizes.
+	c.mu.RLock()
+	if cached, ok := c.size[n]; ok {
+		c.mu.RUnlock()
+		return cached, nil
+	}
+	c.mu.RUnlock()
+
+	// Write-lock slow path for cache miss.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if cached, ok := c.size[n]; ok {

--- a/server/internal/filexfer/encoding/codec.go
+++ b/server/internal/filexfer/encoding/codec.go
@@ -211,7 +211,7 @@ func acquirePooledZstdDecoder(src io.Reader) (*zstd.Decoder, error) {
 			decoder.Close()
 		}
 	}
-	return zstd.NewReader(src)
+	return zstd.NewReader(src, zstd.WithDecoderConcurrency(1))
 }
 
 func releasePooledZstdDecoder(decoder *zstd.Decoder) {

--- a/server/internal/filexfer/encoding/codec.go
+++ b/server/internal/filexfer/encoding/codec.go
@@ -244,7 +244,7 @@ func releasePooledLZ4Reader(reader *lz4.Reader) {
 }
 
 func MaxFrameWireSizeHintBytes(comp string, logicalSize int64) (int64, error) {
-	maxWire, err := maxEncodedFrameSizeBytes(comp, logicalSize)
+	maxWire, err := MaxEncodedFrameSizeBytes(comp, logicalSize)
 	if err != nil {
 		return 0, err
 	}
@@ -296,14 +296,6 @@ func ceilingMaxWSizeBucketBytes(size int64) int64 {
 		return maxWSizeBucket32MiB
 	}
 	return maxWSizeBucket64MiB
-}
-
-func maxEncodedFrameSizeBytes(comp string, logicalSize int64) (int64, error) {
-	return MaxEncodedFrameSizeBytes(comp, logicalSize)
-}
-
-func CeilingMaxWSizeBucketBytes(size int64) int64 {
-	return ceilingMaxWSizeBucketBytes(size)
 }
 
 func FormatXXH128HashToken(v xxh3.Uint128) string {

--- a/server/internal/filexfer/encoding/codec_test.go
+++ b/server/internal/filexfer/encoding/codec_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestMaxEncodedFrameSizeBytesZstdStableAcrossCalls(t *testing.T) {
 	const logicalSize = int64(8 * 1024 * 1024)
-	first, err := maxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
+	first, err := MaxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
 	if err != nil {
 		t.Fatalf("first call failed: %v", err)
 	}
 	for i := 0; i < 20; i++ {
-		next, err := maxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
+		next, err := MaxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
 		if err != nil {
 			t.Fatalf("repeat call %d failed: %v", i, err)
 		}
@@ -26,7 +26,7 @@ func TestMaxEncodedFrameSizeBytesZstdStableAcrossCalls(t *testing.T) {
 func TestMaxEncodedFrameSizeBytesMultipleModesUnaffected(t *testing.T) {
 	const logicalSize = int64(1024)
 
-	noneSize, err := maxEncodedFrameSizeBytes("none", logicalSize)
+	noneSize, err := MaxEncodedFrameSizeBytes("none", logicalSize)
 	if err != nil {
 		t.Fatalf("none sizing failed: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestMaxEncodedFrameSizeBytesMultipleModesUnaffected(t *testing.T) {
 		t.Fatalf("none sizing mismatch: got=%d want=%d", noneSize, logicalSize)
 	}
 
-	lz4Size, err := maxEncodedFrameSizeBytes(EncodingLz4, logicalSize)
+	lz4Size, err := MaxEncodedFrameSizeBytes(EncodingLz4, logicalSize)
 	if err != nil {
 		t.Fatalf("lz4 sizing failed: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestMaxEncodedFrameSizeBytesMultipleModesUnaffected(t *testing.T) {
 		t.Fatalf("lz4 sizing unexpectedly small: %d", lz4Size)
 	}
 
-	zstdSize, err := maxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
+	zstdSize, err := MaxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
 	if err != nil {
 		t.Fatalf("zstd sizing failed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestMaxEncodedFrameSizeBytesZstdConcurrent(t *testing.T) {
 	const goroutines = 32
 	const logicalSize = int64(4 * 1024 * 1024)
 
-	want, err := maxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
+	want, err := MaxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
 	if err != nil {
 		t.Fatalf("baseline call failed: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestMaxEncodedFrameSizeBytesZstdConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			got, callErr := maxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
+			got, callErr := MaxEncodedFrameSizeBytes(EncodingZstd, logicalSize)
 			if callErr != nil {
 				errCh <- callErr
 				return

--- a/server/internal/filexfer/encoding/manifest.go
+++ b/server/internal/filexfer/encoding/manifest.go
@@ -1,0 +1,347 @@
+package encoding
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/jolynch/pinch/utils"
+)
+
+// ManifestEntry is the internal representation of one FM/2 manifest line.
+type ManifestEntry struct {
+	ID    uint64
+	Size  int64
+	Mtime int64
+	Mode  os.FileMode
+	Path  string
+}
+
+// ManifestHeader is the parsed FM/2 header line.
+type ManifestHeader struct {
+	TransferID  string
+	Root        string
+	Mode        string
+	LinkMbps    int64
+	Concurrency int
+}
+
+// EncodePathToken front-codes current against prev and returns a "prefix:suffixLen:suffix" token.
+func EncodePathToken(prev string, current string) string {
+	prefixLen := utils.CommonPrefixLen(prev, current)
+	suffix := current[prefixLen:]
+	return strconv.Itoa(prefixLen) + ":" + strconv.Itoa(len(suffix)) + ":" + suffix
+}
+
+// DecodePathToken decodes a "prefix:suffixLen:suffix" token against prev.
+func DecodePathToken(prev string, token string) (string, error) {
+	first := strings.IndexByte(token, ':')
+	if first < 0 {
+		return "", errors.New("invalid path token")
+	}
+	second := strings.IndexByte(token[first+1:], ':')
+	if second < 0 {
+		return "", errors.New("invalid path token")
+	}
+	second += first + 1
+	prefixLen, err := strconv.Atoi(token[:first])
+	if err != nil || prefixLen < 0 {
+		return "", errors.New("invalid path prefix length")
+	}
+	if prefixLen > len(prev) {
+		return "", errors.New("path prefix length exceeds previous value")
+	}
+	suffixLen, err := strconv.Atoi(token[first+1 : second])
+	if err != nil || suffixLen < 0 {
+		return "", errors.New("invalid path suffix length")
+	}
+	suffix := token[second+1:]
+	if len(suffix) != suffixLen {
+		return "", errors.New("path suffix length mismatch")
+	}
+	if prev == "" && prefixLen != 0 {
+		return "", errors.New("first path prefix length must be zero")
+	}
+	return prev[:prefixLen] + suffix, nil
+}
+
+// EncodeMtimeToken front-codes current against prev and returns a "prefix:suffix" token.
+func EncodeMtimeToken(prev string, current string) (string, error) {
+	if current == "" {
+		return "", errors.New("empty mtime")
+	}
+	for _, ch := range current {
+		if ch < '0' || ch > '9' {
+			return "", errors.New("mtime must be decimal digits")
+		}
+	}
+	prefixLen := utils.CommonPrefixLen(prev, current)
+	suffix := current[prefixLen:]
+	if suffix == "" {
+		if len(current) == 0 {
+			return "", errors.New("mtime cannot be empty")
+		}
+		prefixLen = len(current) - 1
+		suffix = current[prefixLen:]
+	}
+	return strconv.Itoa(prefixLen) + ":" + suffix, nil
+}
+
+// DecodeMtimeToken decodes a "prefix:suffix" token against prev.
+func DecodeMtimeToken(prev string, token string) (string, error) {
+	head, suffix, ok := strings.Cut(token, ":")
+	if !ok {
+		return "", errors.New("invalid mtime token")
+	}
+	prefixLen, err := strconv.Atoi(head)
+	if err != nil || prefixLen < 0 {
+		return "", errors.New("invalid mtime prefix length")
+	}
+	if prefixLen > len(prev) {
+		return "", errors.New("mtime prefix length exceeds previous value")
+	}
+	if suffix == "" {
+		return "", errors.New("empty mtime suffix")
+	}
+	for _, ch := range suffix {
+		if ch < '0' || ch > '9' {
+			return "", errors.New("mtime suffix must be decimal digits")
+		}
+	}
+	if prev == "" && prefixLen != 0 {
+		return "", errors.New("first mtime prefix length must be zero")
+	}
+	return prev[:prefixLen] + suffix, nil
+}
+
+// FormatManifestMode formats a file mode as a 4-digit octal string.
+func FormatManifestMode(mode os.FileMode) string {
+	bits := mode.Perm() | (mode & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky))
+	return fmt.Sprintf("%04o", bits)
+}
+
+// ParseManifestModeToken parses a 4-digit octal mode string.
+func ParseManifestModeToken(raw string) (os.FileMode, error) {
+	if raw == "" {
+		return 0, errors.New("manifest mode is required")
+	}
+	for _, ch := range raw {
+		if ch < '0' || ch > '7' {
+			return 0, errors.New("manifest mode must be octal")
+		}
+	}
+	v, err := strconv.ParseUint(raw, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid manifest mode: %w", err)
+	}
+	if v > 0o7777 {
+		return 0, errors.New("manifest mode must be <= 07777")
+	}
+	return os.FileMode(v), nil
+}
+
+// ParseManifestEntry parses a single FM/2 manifest entry line.
+// Returns the parsed entry, the resolved path, and the resolved mtime string.
+func ParseManifestEntry(line string, prevPath string, prevMtime string) (ManifestEntry, string, string, error) {
+	first := strings.IndexByte(line, ' ')
+	if first <= 0 {
+		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
+	}
+	second := strings.IndexByte(line[first+1:], ' ')
+	if second < 0 {
+		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
+	}
+	second += first + 1
+	third := strings.IndexByte(line[second+1:], ' ')
+	if third < 0 {
+		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
+	}
+	third += second + 1
+	fourth := strings.IndexByte(line[third+1:], ' ')
+	if fourth < 0 {
+		return ManifestEntry{}, "", "", errors.New("invalid manifest entry")
+	}
+	fourth += third + 1
+
+	idRaw := line[:first]
+	sizeRaw := line[first+1 : second]
+	mtimeToken := line[second+1 : third]
+	modeRaw := line[third+1 : fourth]
+	pathToken := line[fourth+1:]
+
+	id, err := strconv.ParseUint(idRaw, 10, 64)
+	if err != nil {
+		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest id: %w", err)
+	}
+	sizeU, err := strconv.ParseUint(sizeRaw, 10, 64)
+	if err != nil {
+		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest size: %w", err)
+	}
+	if sizeU > uint64(^uint64(0)>>1) {
+		return ManifestEntry{}, "", "", errors.New("manifest size overflows int64")
+	}
+
+	mtimeResolved, err := DecodeMtimeToken(prevMtime, mtimeToken)
+	if err != nil {
+		return ManifestEntry{}, "", "", err
+	}
+	mtimeNanos, err := strconv.ParseUint(mtimeResolved, 10, 64)
+	if err != nil {
+		return ManifestEntry{}, "", "", fmt.Errorf("invalid manifest mtime value: %w", err)
+	}
+	if mtimeNanos > uint64(^uint64(0)>>1) {
+		return ManifestEntry{}, "", "", errors.New("manifest mtime overflows int64")
+	}
+	mode, err := ParseManifestModeToken(modeRaw)
+	if err != nil {
+		return ManifestEntry{}, "", "", err
+	}
+
+	pathResolved, err := DecodePathToken(prevPath, pathToken)
+	if err != nil {
+		return ManifestEntry{}, "", "", err
+	}
+	if strings.Contains(pathResolved, `\`) {
+		return ManifestEntry{}, "", "", errors.New("manifest path contains backslash")
+	}
+	if strings.HasPrefix(pathResolved, "/") {
+		return ManifestEntry{}, "", "", errors.New("manifest path must be relative")
+	}
+	cleanPath := filepath.Clean(filepath.FromSlash(pathResolved))
+	if cleanPath == "." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) || cleanPath == ".." {
+		return ManifestEntry{}, "", "", errors.New("manifest path traversal is not allowed")
+	}
+
+	entry := ManifestEntry{
+		ID:    id,
+		Size:  int64(sizeU),
+		Mtime: int64(mtimeNanos),
+		Mode:  mode,
+		Path:  pathResolved,
+	}
+	return entry, pathResolved, mtimeResolved, nil
+}
+
+// MarshalManifestEntry serializes a single manifest entry using front-coding
+// against the previous path and mtime. Returns the line (without trailing newline),
+// the current path, and the current mtime string.
+func MarshalManifestEntry(entry ManifestEntry, prevPath string, prevMtime string) (string, string, string, error) {
+	if entry.Size < 0 {
+		return "", "", "", fmt.Errorf("manifest size must be >= 0 for id=%d", entry.ID)
+	}
+	if strings.Contains(entry.Path, `\`) {
+		return "", "", "", fmt.Errorf("manifest path contains backslash: %q", entry.Path)
+	}
+	if strings.HasPrefix(entry.Path, "/") {
+		return "", "", "", fmt.Errorf("manifest path must be relative: %q", entry.Path)
+	}
+	cleanPath := filepath.Clean(filepath.FromSlash(entry.Path))
+	if cleanPath == "." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) || cleanPath == ".." {
+		return "", "", "", fmt.Errorf("manifest path traversal is not allowed: %q", entry.Path)
+	}
+	modeToken := FormatManifestMode(entry.Mode)
+	mtimeRaw := strconv.FormatInt(entry.Mtime, 10)
+	mtimeToken, err := EncodeMtimeToken(prevMtime, mtimeRaw)
+	if err != nil {
+		return "", "", "", fmt.Errorf("encode manifest mtime id=%d: %w", entry.ID, err)
+	}
+	pathToken := EncodePathToken(prevPath, entry.Path)
+	line := fmt.Sprintf("%d %d %s %s %s", entry.ID, entry.Size, mtimeToken, modeToken, pathToken)
+	return line, entry.Path, mtimeRaw, nil
+}
+
+// ParseManifestHeader parses an FM/2 header line and returns the header fields.
+func ParseManifestHeader(line string) (ManifestHeader, error) {
+	rest := strings.TrimPrefix(line, "FM/2 ")
+	sep := strings.IndexByte(rest, ' ')
+	if sep <= 0 || sep == len(rest)-1 {
+		return ManifestHeader{}, errors.New("invalid manifest header")
+	}
+	txferID := rest[:sep]
+	rootRaw := rest[sep+1:]
+	root, consumed, err := ParseLenPrefixedPrefix(rootRaw)
+	if err != nil {
+		return ManifestHeader{}, fmt.Errorf("invalid manifest root token: %w", err)
+	}
+	optionsRaw := strings.TrimSpace(rootRaw[consumed:])
+	if optionsRaw == "" {
+		return ManifestHeader{}, errors.New("manifest header missing metadata options")
+	}
+	options := strings.Fields(optionsRaw)
+	var (
+		hdr      ManifestHeader
+		seenMode bool
+		seenLink bool
+		seenConc bool
+	)
+	hdr.TransferID = txferID
+	hdr.Root = root
+	for _, option := range options {
+		key, value, ok := strings.Cut(option, "=")
+		if !ok {
+			return ManifestHeader{}, errors.New("invalid manifest header option")
+		}
+		switch key {
+		case "mode":
+			value = strings.ToLower(strings.TrimSpace(value))
+			if value != "fast" && value != "gentle" {
+				return ManifestHeader{}, errors.New("invalid manifest mode")
+			}
+			hdr.Mode = value
+			seenMode = true
+		case "link-mbps":
+			hdr.LinkMbps, err = strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+			if err != nil || hdr.LinkMbps < 0 {
+				return ManifestHeader{}, errors.New("invalid manifest link-mbps")
+			}
+			seenLink = true
+		case "concurrency":
+			hdr.Concurrency, err = strconv.Atoi(strings.TrimSpace(value))
+			if err != nil || hdr.Concurrency <= 0 {
+				return ManifestHeader{}, errors.New("invalid manifest concurrency")
+			}
+			seenConc = true
+		default:
+			return ManifestHeader{}, errors.New("unknown manifest header option")
+		}
+	}
+	if !seenMode || !seenLink || !seenConc {
+		return ManifestHeader{}, errors.New("manifest header missing required metadata")
+	}
+	return hdr, nil
+}
+
+// FormatManifestHeader formats an FM/2 header line (without trailing newline).
+func FormatManifestHeader(hdr ManifestHeader) string {
+	return fmt.Sprintf(
+		"FM/2 %s %d:%s mode=%s link-mbps=%d concurrency=%d",
+		hdr.TransferID,
+		len(hdr.Root),
+		hdr.Root,
+		hdr.Mode,
+		hdr.LinkMbps,
+		hdr.Concurrency,
+	)
+}
+
+// ParseLenPrefixedPrefix parses a "len:value" token at the start of raw.
+// Returns the value, the number of bytes consumed, and any error.
+func ParseLenPrefixedPrefix(raw string) (string, int, error) {
+	sep := strings.IndexByte(raw, ':')
+	if sep <= 0 {
+		return "", 0, errors.New("invalid len-prefixed token")
+	}
+	n, err := strconv.Atoi(raw[:sep])
+	if err != nil || n < 0 {
+		return "", 0, errors.New("invalid len prefix")
+	}
+	start := sep + 1
+	end := start + n
+	if end > len(raw) {
+		return "", 0, errors.New("len prefix mismatch")
+	}
+	return raw[start:end], end, nil
+}

--- a/server/internal/filexfer/ftcp/request.go
+++ b/server/internal/filexfer/ftcp/request.go
@@ -59,6 +59,25 @@ func ParseRequest(payload []byte) (Request, error) {
 		}
 		req.Params = append(req.Params, param)
 		return req, nil
+	case VerbSYNC:
+		directory, readErr := c.readPathValue()
+		if readErr != nil {
+			return Request{}, protocolErr{code: "BAD_REQUEST", message: "invalid SYNC directory"}
+		}
+		param := map[string]string{"directory": string(directory)}
+		for !c.eof() {
+			tok, tokErr := c.readToken()
+			if tokErr != nil {
+				return Request{}, protocolErr{code: "BAD_REQUEST", message: "invalid SYNC option"}
+			}
+			key, val, ok := strings.Cut(tok, "=")
+			if !ok {
+				return Request{}, protocolErr{code: "BAD_REQUEST", message: "invalid SYNC option"}
+			}
+			param[key] = val
+		}
+		req.Params = append(req.Params, param)
+		return req, nil
 	case VerbSEND:
 		txferID, readErr := c.readToken()
 		if readErr != nil || txferID == "" {

--- a/server/internal/filexfer/ftcp/send.go
+++ b/server/internal/filexfer/ftcp/send.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"net"
 	"os"
 	"runtime"
 	"runtime/trace"
@@ -63,6 +64,7 @@ type frameStreamArgs struct {
 	TerminalMD    *encoding.FileFrameMetadata
 	WindowHasher  *xxh3.Hasher128
 	Output        io.Writer
+	OutputTCPConn *net.TCPConn
 	PipeSizeBytes int
 	DirectIO      bool
 }
@@ -207,7 +209,6 @@ func streamSendItem(ctx context.Context, out io.Writer, deps Deps, txferID strin
 		return protocolErr{code: "INTERNAL", message: "failed to compute max frame size hint"}
 	}
 	pipeSizeBytes := desiredPipeSizeBytes(windowLen, firstFrameLogical)
-	useLinuxSplice := runtime.GOOS == "linux" && item.Mode == loadStrategyFast
 	firstFrame := true
 
 	adaptive := item.Comp == "adapt"
@@ -249,14 +250,15 @@ func streamSendItem(ctx context.Context, out io.Writer, deps Deps, txferID strin
 			TerminalMD:    terminalMD,
 			WindowHasher:  windowHasher,
 			Output:        out,
+			OutputTCPConn: extractTCPConn(out),
 			PipeSizeBytes: pipeSizeBytes,
 			DirectIO:      usedDirectOpen,
 		}
 
 		frameOffset := cursor
 		var stats frameStreamStats
-		if useLinuxSplice {
-			stats, err = streamFramePayloadLinuxSplice(fd, &frameOffset, frameArgs)
+		if canZeroCopy(frameArgs) {
+			stats, err = streamFramePayloadZeroCopy(fd, &frameOffset, frameArgs)
 		} else {
 			stats, err = streamFramePayloadBuffered(fd, &frameOffset, frameArgs)
 		}
@@ -273,7 +275,6 @@ func streamSendItem(ctx context.Context, out io.Writer, deps Deps, txferID strin
 					return mapLookupError(err)
 				}
 				usedDirectOpen = false
-				useLinuxSplice = runtime.GOOS == "linux" && item.Mode == loadStrategyFast
 				remaining = item.Offset + windowLen - cursor
 				if remaining < 0 {
 					return protocolErr{code: "INTERNAL", message: "invalid resume offset after direct I/O retry"}
@@ -389,6 +390,30 @@ func isDirectIOReadError(err error) bool {
 		return false
 	}
 	return errors.Is(err, syscall.EINVAL) || errors.Is(err, unix.EINVAL)
+}
+
+// canZeroCopy reports whether a frame can use the tee+splice zero-copy send
+// path, which avoids copying payload bytes into userspace for the network
+// write. The path requires all of:
+//   - Linux (tee/splice are Linux-only syscalls)
+//   - No compression (compressed data must be assembled in userspace)
+//   - No O_DIRECT (direct I/O requires aligned userspace buffers, not pipes)
+//   - A raw TCP socket (no encryption or rate-limit wrapper over the conn)
+func canZeroCopy(args frameStreamArgs) bool {
+	return runtime.GOOS == "linux" &&
+		args.Comp == "none" &&
+		!args.DirectIO &&
+		args.OutputTCPConn != nil
+}
+
+func extractTCPConn(w io.Writer) *net.TCPConn {
+	if cw, ok := w.(*countingWriter); ok {
+		w = cw.w
+	}
+	if tc, ok := w.(*net.TCPConn); ok {
+		return tc
+	}
+	return nil
 }
 
 func initialCompressionMode(comp string) policy.CompressionMode {
@@ -622,18 +647,56 @@ func streamFramePayloadBuffered(fd *os.File, fileOffset *int64, args frameStream
 	}, nil
 }
 
-func streamFramePayloadLinuxSplice(fd *os.File, fileOffset *int64, args frameStreamArgs) (frameStreamStats, error) {
-	if args.Comp == "none" && args.DirectIO {
-		return streamFramePayloadBuffered(fd, fileOffset, args)
+func dupConnFD(conn *net.TCPConn) (int, error) {
+	raw, err := conn.SyscallConn()
+	if err != nil {
+		return -1, err
 	}
+	dupFD := -1
+	var dupErr error
+	if err := raw.Control(func(fd uintptr) {
+		dupFD, dupErr = unix.Dup(int(fd))
+	}); err != nil {
+		return -1, err
+	}
+	if dupErr != nil {
+		return -1, dupErr
+	}
+	if dupFD < 0 {
+		return -1, errors.New("failed to duplicate connection fd")
+	}
+	return dupFD, nil
+}
 
+const zeroCopyPollTimeoutMs = 30_000 // 30s per poll wait
+
+func waitSocketWritable(fd int) error {
+	pollFDs := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLOUT}}
+	for {
+		n, err := unix.Poll(pollFDs, zeroCopyPollTimeoutMs)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return err
+		}
+		if n == 0 {
+			return errors.New("zero-copy splice timed out waiting for socket writable")
+		}
+		if pollFDs[0].Revents&(unix.POLLERR|unix.POLLHUP) != 0 {
+			return errors.New("socket error during zero-copy splice")
+		}
+		return nil
+	}
+}
+
+func streamFramePayloadZeroCopy(fd *os.File, fileOffset *int64, args frameStreamArgs) (frameStreamStats, error) {
 	srcR, srcW, err := os.Pipe()
 	if err != nil {
 		return frameStreamStats{}, err
 	}
 	defer srcR.Close()
 	defer srcW.Close()
-
 	growPipeBestEffort(srcR, args.PipeSizeBytes)
 	growPipeBestEffort(srcW, args.PipeSizeBytes)
 
@@ -644,42 +707,42 @@ func streamFramePayloadLinuxSplice(fd *os.File, fileOffset *int64, args frameStr
 	}
 	defer releaseCopyBuf()
 
+	outFD, err := dupConnFD(args.OutputTCPConn)
+	if err != nil {
+		return frameStreamStats{}, err
+	}
+	defer unix.Close(outFD)
+
+	// Hash pipe: tee duplicates pipe1 data here for hashing, while pipe1
+	// data is spliced directly to the socket without entering userspace.
+	hashPipeR, hashPipeW, err := os.Pipe()
+	if err != nil {
+		return frameStreamStats{}, err
+	}
+	defer hashPipeR.Close()
+	defer hashPipeW.Close()
+	growPipeBestEffort(hashPipeR, args.PipeSizeBytes)
+	growPipeBestEffort(hashPipeW, args.PipeSizeBytes)
+
 	writeLatency := time.Duration(0)
-	isCompressed := args.Comp != "none"
-
-	// For compressed: buffer payload into frameBuf so wireSize is known before writing the header.
-	// For none: wireSize == frameSize, write the header immediately and splice directly.
-	payloadWriter := io.Writer(args.Output)
-	var frameBuf *bytes.Buffer
-	var closeCompWriter func() error
-
-	if isCompressed {
-		frameBuf = acquireCompressedFrameBuffer(args.FrameSize, args.Comp)
-		defer releaseCompressedFrameBuffer(frameBuf)
-		var compWriter io.Writer
-		var selected string
-		compWriter, closeCompWriter, selected, err = encoding.WrapCompressedWriter(frameBuf, args.Comp, args.Mode)
-		if err != nil {
-			return frameStreamStats{}, err
-		}
-		if selected != args.Comp {
-			return frameStreamStats{}, errors.New("compression mode negotiation mismatch")
-		}
-		payloadWriter = compWriter
-	} else {
-		if err := writeFrameHeader(args.Output, args, args.FrameSize, &writeLatency); err != nil {
-			return frameStreamStats{}, err
-		}
+	if err := writeFrameHeader(args.Output, args, args.FrameSize, &writeLatency); err != nil {
+		return frameStreamStats{}, err
 	}
 
 	prepareLatency := time.Duration(0)
 	remaining := args.FrameSize
-	readRegion := trace.StartRegion(args.Ctx, "frame-read")
+
+	// Fd() puts these into blocking mode — required for raw tee/splice syscalls.
+	srcRFD := int(srcR.Fd())
+	hashPipeWFD := int(hashPipeW.Fd())
+
+	readRegion := trace.StartRegion(args.Ctx, "frame-read-zerocopy")
 	for remaining > 0 {
 		step := remaining
 		if step > int64(args.PipeSizeBytes) {
 			step = int64(args.PipeSizeBytes)
 		}
+
 		spliceStart := time.Now()
 		splicedIn, spliceErr := unix.Splice(int(fd.Fd()), fileOffset, int(srcW.Fd()), nil, int(step), unix.SPLICE_F_MOVE)
 		prepareLatency += time.Since(spliceStart)
@@ -692,63 +755,67 @@ func streamFramePayloadLinuxSplice(fd *os.File, fileOffset *int64, args frameStr
 			return frameStreamStats{}, io.ErrUnexpectedEOF
 		}
 
-		sourceRemaining := int64(splicedIn)
+		// tee(2) does not consume src bytes. If tee returns a partial
+		// duplicate, we must consume exactly that amount from src before
+		// calling tee again, otherwise we'd duplicate the same prefix
+		// repeatedly.
+		sourceRemaining := splicedIn
 		for sourceRemaining > 0 {
-			chunk := sourceRemaining
-			if chunk > int64(len(copyBuf)) {
-				chunk = int64(len(copyBuf))
+			teeStart := time.Now()
+			teed, teeErr := unix.Tee(srcRFD, hashPipeWFD, int(sourceRemaining), 0)
+			prepareLatency += time.Since(teeStart)
+			if teeErr != nil {
+				readRegion.End()
+				return frameStreamStats{}, teeErr
 			}
+			if teed <= 0 {
+				readRegion.End()
+				return frameStreamStats{}, io.ErrUnexpectedEOF
+			}
+
+			// splice: consume teed bytes from pipe1 → socket (zero-copy)
+			writeStart := time.Now()
+			moveRemaining := teed
+			for moveRemaining > 0 {
+				moved, moveErr := unix.Splice(srcRFD, nil, outFD, nil, int(moveRemaining), unix.SPLICE_F_MOVE)
+				if moveErr != nil {
+					if errors.Is(moveErr, unix.EINTR) {
+						continue
+					}
+					if errors.Is(moveErr, unix.EAGAIN) {
+						if waitErr := waitSocketWritable(outFD); waitErr != nil {
+							readRegion.End()
+							return frameStreamStats{}, waitErr
+						}
+						continue
+					}
+					readRegion.End()
+					return frameStreamStats{}, moveErr
+				}
+				if moved <= 0 {
+					readRegion.End()
+					return frameStreamStats{}, io.ErrUnexpectedEOF
+				}
+				moveRemaining -= moved
+			}
+			writeLatency += time.Since(writeStart)
+
+			// read from hash pipe + hash (the only userspace copy)
 			readStart := time.Now()
-			n, readErr := io.ReadFull(srcR, copyBuf[:chunk])
+			n, readErr := io.ReadFull(hashPipeR, copyBuf[:teed])
 			prepareLatency += time.Since(readStart)
 			if n > 0 {
 				_, _ = args.WindowHasher.Write(copyBuf[:n])
-				writeStart := time.Now()
-				written, writeErr := payloadWriter.Write(copyBuf[:n])
-				if !isCompressed {
-					writeLatency += time.Since(writeStart)
-				} else {
-					prepareLatency += time.Since(writeStart)
-				}
-				if writeErr != nil {
-					readRegion.End()
-					return frameStreamStats{}, writeErr
-				}
-				if written != n {
-					readRegion.End()
-					return frameStreamStats{}, io.ErrShortWrite
-				}
-				sourceRemaining -= int64(n)
 			}
 			if readErr != nil {
 				readRegion.End()
 				return frameStreamStats{}, readErr
 			}
+			sourceRemaining -= teed
 		}
-		remaining -= int64(splicedIn)
+		remaining -= splicedIn
 	}
 	readRegion.End()
-
-	wireSize := args.FrameSize
-	if isCompressed {
-		compRegion := trace.StartRegion(args.Ctx, "frame-compress")
-		if err := closeCompWriter(); err != nil {
-			compRegion.End()
-			return frameStreamStats{}, err
-		}
-		wireSize = int64(frameBuf.Len())
-		if err := writeFrameHeader(args.Output, args, wireSize, &writeLatency); err != nil {
-			compRegion.End()
-			return frameStreamStats{}, err
-		}
-		writeStart := time.Now()
-		if _, err := args.Output.Write(frameBuf.Bytes()); err != nil {
-			compRegion.End()
-			return frameStreamStats{}, err
-		}
-		writeLatency += time.Since(writeStart)
-		compRegion.End()
-	}
 
 	windowHashToken, err := writeFrameTrailer(args.Output, args, &writeLatency)
 	if err != nil {
@@ -757,7 +824,7 @@ func streamFramePayloadLinuxSplice(fd *os.File, fileOffset *int64, args frameStr
 
 	return frameStreamStats{
 		LogicalSize:     args.FrameSize,
-		WireSize:        wireSize,
+		WireSize:        args.FrameSize,
 		PrepareLatency:  prepareLatency,
 		WriteLatency:    writeLatency,
 		NextOffset:      *fileOffset,

--- a/server/internal/filexfer/ftcp/server.go
+++ b/server/internal/filexfer/ftcp/server.go
@@ -23,6 +23,7 @@ type ServerOptions struct {
 	Deps                   Deps
 	Limiter                *limit.Limiter
 	SocketWriteBufferBytes int
+	SyncTimeout            time.Duration // 0 = no timeout; bounds SYNC response write time
 }
 
 type HandlerFunc func(context.Context, Request, io.Writer, Deps) error
@@ -35,6 +36,7 @@ var handlers = map[Verb]HandlerFunc{
 	VerbCXSUM:  handleCXSUM,
 	VerbSTATUS: handleSTATUS,
 	VerbPROBE:  handlePROBECommand,
+	VerbSYNC:   handleSYNCCommand,
 }
 
 func Serve(listener net.Listener, opts ServerOptions) error {
@@ -65,6 +67,7 @@ type connSession struct {
 	deps                   Deps
 	limiter                *limit.Limiter
 	socketWriteBufferBytes int
+	syncTimeout            time.Duration
 	respOut                io.Writer
 	closeResp              func() error
 	wroteBytes             bool
@@ -79,6 +82,7 @@ func handleConn(conn net.Conn, opts ServerOptions, deps Deps) {
 		deps:                   deps,
 		limiter:                opts.Limiter,
 		socketWriteBufferBytes: opts.SocketWriteBufferBytes,
+		syncTimeout:            opts.SyncTimeout,
 		respOut:                conn,
 		closeResp:              func() error { return nil },
 	}
@@ -153,7 +157,7 @@ func (s *connSession) run() error {
 		s.wroteBytes = countingOut.n > 0
 		return err
 	}
-	if cmdReq.Verb == VerbTXFER || cmdReq.Verb == VerbSEND || cmdReq.Verb == VerbCXSUM || cmdReq.Verb == VerbPROBE {
+	if cmdReq.Verb == VerbTXFER || cmdReq.Verb == VerbSEND || cmdReq.Verb == VerbCXSUM || cmdReq.Verb == VerbPROBE || cmdReq.Verb == VerbSYNC {
 		if err := writeOKLine(countingOut, ""); err != nil {
 			s.wroteBytes = countingOut.n > 0
 			return err
@@ -169,6 +173,12 @@ func (s *connSession) handleCommand(ctx context.Context, req Request, in io.Read
 	}
 	if req.Verb == VerbPROBE {
 		return handlePROBEWithInput(ctx, req, in, out, s.deps)
+	}
+	if req.Verb == VerbSYNC {
+		if s.syncTimeout > 0 {
+			_ = s.conn.SetWriteDeadline(time.Now().Add(s.syncTimeout))
+		}
+		return handleSYNCWithInput(ctx, req, in, out, s.deps)
 	}
 	handler, ok := handlers[req.Verb]
 	if !ok || req.Verb == VerbUnknown {

--- a/server/internal/filexfer/ftcp/sync.go
+++ b/server/internal/filexfer/ftcp/sync.go
@@ -1,0 +1,282 @@
+package ftcp
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/jolynch/pinch/internal/filexfer/encoding"
+	"github.com/zeebo/xxh3"
+)
+
+type syncRequest struct {
+	Directory   string
+	Mode        string
+	LinkMbps    int64
+	Concurrency int
+}
+
+type oldEntry struct {
+	size   int64
+	mtime  int64
+	mode   os.FileMode
+	fileID uint64
+	seen   bool
+}
+
+func parseSYNCRequest(req Request) (syncRequest, error) {
+	if req.Verb != VerbSYNC {
+		return syncRequest{}, protocolErr{code: "BAD_COMMAND", message: "not SYNC"}
+	}
+	if len(req.Params) != 1 {
+		return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "invalid SYNC arguments"}
+	}
+	p := req.Params[0]
+	for key := range p {
+		switch key {
+		case "directory", "mode", "link-mbps", "concurrency":
+		default:
+			return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "unknown SYNC option"}
+		}
+	}
+	directory := p["directory"]
+	if strings.TrimSpace(directory) == "" {
+		return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "missing SYNC directory"}
+	}
+	mode := strings.ToLower(strings.TrimSpace(p["mode"]))
+	if mode != "fast" && mode != "gentle" {
+		return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "mode must be fast or gentle"}
+	}
+	linkMbps, err := strconv.ParseInt(strings.TrimSpace(p["link-mbps"]), 10, 64)
+	if err != nil || linkMbps < 0 {
+		return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "link-mbps must be >= 0"}
+	}
+	concurrency, err := strconv.Atoi(strings.TrimSpace(p["concurrency"]))
+	if err != nil || concurrency <= 0 {
+		return syncRequest{}, protocolErr{code: "BAD_REQUEST", message: "concurrency must be > 0"}
+	}
+	return syncRequest{
+		Directory:   directory,
+		Mode:        mode,
+		LinkMbps:    linkMbps,
+		Concurrency: concurrency,
+	}, nil
+}
+
+// handleSYNCCommand is the placeholder in the handlers map. The real work
+// is done by handleSYNCWithInput which needs the io.Reader for manifest body.
+func handleSYNCCommand(_ context.Context, _ Request, _ io.Writer, _ Deps) error {
+	return protocolErr{code: "INTERNAL", message: "SYNC requires input reader, use handleSYNCWithInput"}
+}
+
+func handleSYNCWithInput(ctx context.Context, req Request, in io.Reader, out io.Writer, deps Deps) error {
+	parsed, err := parseSYNCRequest(req)
+	if err != nil {
+		return err
+	}
+	if err := validateDirectory(parsed.Directory); err != nil {
+		return protocolErr{code: "UNPROCESSABLE", message: err.Error()}
+	}
+
+	root := filepath.Clean(parsed.Directory)
+
+	// Read old manifest from input stream (lines until blank line).
+	pathIndex, parseErr := readOldManifest(in)
+	if parseErr != nil {
+		return protocolErr{code: "BAD_REQUEST", message: fmt.Sprintf("invalid old manifest: %s", parseErr)}
+	}
+
+	// Create transfer and set hints (same pattern as TXFER).
+	transfer, err := deps.NewTransfer(root, 0, 0)
+	if err != nil {
+		return protocolErr{code: "INTERNAL", message: "failed to initialize transfer"}
+	}
+	if ok := deps.SetTransferHints(transfer.ID, parsed.Mode, parsed.LinkMbps, parsed.Concurrency); !ok {
+		return protocolErr{code: "INTERNAL", message: "failed to persist transfer hints"}
+	}
+	manifestMode := parsed.Mode
+	manifestLinkMbps := parsed.LinkMbps
+	manifestConcurrency := parsed.Concurrency
+	if stored, ok := deps.GetTransfer(transfer.ID); ok {
+		if strings.TrimSpace(stored.Mode) != "" {
+			manifestMode = strings.ToLower(strings.TrimSpace(stored.Mode))
+		}
+		if stored.LinkMbps >= 0 {
+			manifestLinkMbps = stored.LinkMbps
+		}
+		if stored.Concurrency > 0 {
+			manifestConcurrency = stored.Concurrency
+		}
+	}
+	cleanupTransfer := true
+	defer func() {
+		if cleanupTransfer {
+			deps.DeleteTransfer(transfer.ID)
+		}
+	}()
+
+	// Write FM/2 header.
+	hdr := encoding.FormatManifestHeader(encoding.ManifestHeader{
+		TransferID:  transfer.ID,
+		Root:        root,
+		Mode:        manifestMode,
+		LinkMbps:    manifestLinkMbps,
+		Concurrency: manifestConcurrency,
+	})
+	if _, err := io.WriteString(out, hdr+"\n"); err != nil {
+		if isBrokenPipe(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Walk filesystem and emit manifest entries.
+	updatesCh := make(chan TransferFileStateUpdate, 1000)
+	done := deps.RegisterTransferFileState(transfer.ID, updatesCh, TransferStateStarted)
+	defer func() {
+		close(updatesCh)
+		<-done
+	}()
+	fileID := 0
+	prevPath := ""
+	prevMtime := ""
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entryPath := filepath.ToSlash(rel)
+		entryMtime := info.ModTime().UnixNano()
+		entrySize := info.Size()
+
+		// Mark in pathIndex that this path still exists on disk.
+		// Key by path hash — no path strings stored in the index.
+		pathHash := xxh3.Hash128([]byte(entryPath))
+		if old, ok := pathIndex[pathHash]; ok {
+			old.seen = true
+		}
+
+		// Emit entry.
+		entryMode := encoding.FormatManifestMode(info.Mode())
+		mtimeStr := strconv.FormatInt(entryMtime, 10)
+		pathToken := encoding.EncodePathToken(prevPath, entryPath)
+		mtimeToken, _ := encoding.EncodeMtimeToken(prevMtime, mtimeStr)
+		line := fmt.Sprintf("%d %d %s %s %s\n", fileID, entrySize, mtimeToken, entryMode, pathToken)
+
+		fullPath := filepath.Clean(filepath.Join(root, entryPath))
+		updatesCh <- TransferFileStateUpdate{
+			FileID:   uint64(fileID),
+			PathHash: xxh3.Hash128([]byte(fullPath)),
+			FileSize: entrySize,
+		}
+		if _, err := io.WriteString(out, line); err != nil {
+			return err
+		}
+		prevPath = entryPath
+		prevMtime = mtimeStr
+		fileID++
+		return nil
+	})
+	if walkErr != nil {
+		if isBrokenPipe(walkErr) {
+			return nil
+		}
+		return protocolErr{code: "BAD_REQUEST", message: walkErr.Error()}
+	}
+
+	// Emit RM lines for old paths no longer on disk.
+	// Use the old manifest's fileID — client resolves IDs to paths locally.
+	for _, old := range pathIndex {
+		if old.seen {
+			continue
+		}
+		rmLine := fmt.Sprintf("RM %d\n", old.fileID)
+		if _, err := io.WriteString(out, rmLine); err != nil {
+			if isBrokenPipe(err) {
+				return nil
+			}
+			return err
+		}
+	}
+
+	deps.ClipTransfer(transfer.ID)
+	cleanupTransfer = false
+	return nil
+}
+
+// readOldManifest reads FM/2 manifest lines from in until a blank line.
+// Returns a map keyed by xxh3-128 path hash — no path strings are retained.
+func readOldManifest(in io.Reader) (map[xxh3.Uint128]*oldEntry, error) {
+	br := bufio.NewReader(in)
+	pathIndex := make(map[xxh3.Uint128]*oldEntry)
+	prevPath := ""
+	prevMtime := ""
+	seenHeader := false
+
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		trimmed := strings.TrimSpace(line)
+
+		// Blank line terminates the old manifest body.
+		if trimmed == "" {
+			break
+		}
+
+		if strings.HasPrefix(trimmed, "FM/2 ") {
+			// Parse header but we only need to validate it; we don't use its fields.
+			if _, headerErr := encoding.ParseManifestHeader(trimmed); headerErr != nil {
+				return nil, headerErr
+			}
+			seenHeader = true
+			prevPath = ""
+			prevMtime = ""
+			continue
+		}
+
+		if !seenHeader {
+			return nil, fmt.Errorf("manifest entry before header")
+		}
+
+		entry, nextPath, nextMtime, parseErr := encoding.ParseManifestEntry(trimmed, prevPath, prevMtime)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		// Hash path immediately and discard the string — no path strings retained.
+		pathHash := xxh3.Hash128([]byte(entry.Path))
+		pathIndex[pathHash] = &oldEntry{
+			size:   entry.Size,
+			mtime:  entry.Mtime,
+			mode:   entry.Mode,
+			fileID: entry.ID,
+		}
+		prevPath = nextPath
+		prevMtime = nextMtime
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return pathIndex, nil
+}

--- a/server/internal/filexfer/ftcp/sync_test.go
+++ b/server/internal/filexfer/ftcp/sync_test.go
@@ -1,0 +1,509 @@
+package ftcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jolynch/pinch/internal/filexfer/encoding"
+)
+
+type syncTestDeps struct {
+	txferTestDeps
+}
+
+func TestParseSYNCRequest(t *testing.T) {
+	good := fmt.Sprintf(`SYNC %q mode=fast link-mbps=900 concurrency=12`, "/tmp/test")
+	req, err := ParseRequest([]byte(good))
+	if err != nil {
+		t.Fatalf("ParseRequest failed: %v", err)
+	}
+	parsed, err := parseSYNCRequest(req)
+	if err != nil {
+		t.Fatalf("parseSYNCRequest failed: %v", err)
+	}
+	if parsed.Directory != "/tmp/test" || parsed.Mode != "fast" || parsed.LinkMbps != 900 || parsed.Concurrency != 12 {
+		t.Fatalf("unexpected parsed request: %+v", parsed)
+	}
+
+	bad := []string{
+		`SYNC "/tmp" link-mbps=900 concurrency=12`,
+		`SYNC "/tmp" mode=fast concurrency=12`,
+		`SYNC "/tmp" mode=fast link-mbps=900`,
+		`SYNC "/tmp" mode=slow link-mbps=900 concurrency=12`,
+		`SYNC "/tmp" mode=fast link-mbps=-1 concurrency=12`,
+		`SYNC "/tmp" mode=fast link-mbps=900 concurrency=0`,
+	}
+	for _, raw := range bad {
+		t.Run(raw, func(t *testing.T) {
+			req, err := ParseRequest([]byte(raw))
+			if err != nil {
+				t.Fatalf("ParseRequest failed: %v", err)
+			}
+			if _, err := parseSYNCRequest(req); err == nil {
+				t.Fatalf("expected parseSYNCRequest to fail for %q", raw)
+			}
+		})
+	}
+}
+
+func TestHandleSYNCEmptyOldManifest(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "a.txt", "hello")
+	writeTestFile(t, root, "b.txt", "world")
+
+	newManifest, rmPaths := runSYNCTest(t, root, "")
+	if len(rmPaths) != 0 {
+		t.Fatalf("expected no removals, got %v", rmPaths)
+	}
+	if len(newManifest) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(newManifest))
+	}
+	paths := manifestPaths(newManifest)
+	if paths[0] != "a.txt" || paths[1] != "b.txt" {
+		t.Fatalf("unexpected paths: %v", paths)
+	}
+}
+
+func TestHandleSYNCNoChanges(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "a.txt", "hello")
+	writeTestFile(t, root, "sub/b.txt", "world")
+
+	// Get initial manifest via TXFER.
+	initialManifest := runTXFERTest(t, root)
+
+	// SYNC with that manifest — nothing should be removed.
+	newManifest, rmPaths := runSYNCTest(t, root, initialManifest)
+	if len(rmPaths) != 0 {
+		t.Fatalf("expected no removals, got %v", rmPaths)
+	}
+	if len(newManifest) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(newManifest))
+	}
+}
+
+func TestHandleSYNCAllRemoved(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "a.txt", "hello")
+	writeTestFile(t, root, "b.txt", "world")
+
+	initialManifest := runTXFERTest(t, root)
+
+	// Remove all files.
+	os.Remove(filepath.Join(root, "a.txt"))
+	os.Remove(filepath.Join(root, "b.txt"))
+
+	newManifest, rmPaths := runSYNCTest(t, root, initialManifest)
+	if len(newManifest) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(newManifest))
+	}
+	sort.Strings(rmPaths)
+	if len(rmPaths) != 2 || rmPaths[0] != "a.txt" || rmPaths[1] != "b.txt" {
+		t.Fatalf("unexpected removals: %v", rmPaths)
+	}
+}
+
+func TestHandleSYNCMixedDelta(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "keep.txt", "unchanged")
+	writeTestFile(t, root, "stale.txt", "old content")
+	writeTestFile(t, root, "remove.txt", "will be removed")
+
+	initialManifest := runTXFERTest(t, root)
+
+	// Modify stale.txt (change content and mtime).
+	time.Sleep(10 * time.Millisecond)
+	writeTestFile(t, root, "stale.txt", "new content!!!")
+
+	// Remove remove.txt.
+	os.Remove(filepath.Join(root, "remove.txt"))
+
+	// Add new.txt.
+	writeTestFile(t, root, "new.txt", "brand new")
+
+	newManifest, rmPaths := runSYNCTest(t, root, initialManifest)
+
+	// Should have keep.txt, new.txt, stale.txt in manifest.
+	if len(newManifest) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(newManifest))
+	}
+	paths := manifestPaths(newManifest)
+	// Walk order is alphabetical.
+	if paths[0] != "keep.txt" || paths[1] != "new.txt" || paths[2] != "stale.txt" {
+		t.Fatalf("unexpected paths: %v", paths)
+	}
+
+	// remove.txt should be in removals.
+	if len(rmPaths) != 1 || rmPaths[0] != "remove.txt" {
+		t.Fatalf("unexpected removals: %v", rmPaths)
+	}
+}
+
+
+// --- Test helpers ---
+
+func writeTestFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// runTXFERTest runs TXFER and returns the raw FM/2 manifest output.
+func runTXFERTest(t *testing.T, root string) string {
+	t.Helper()
+	reqRaw := fmt.Sprintf(`TXFER %q mode=fast link-mbps=1000 concurrency=8`, root)
+	req, err := ParseRequest([]byte(reqRaw))
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+	deps := &syncTestDeps{}
+	var out bytes.Buffer
+	if err := handleTXFER(context.Background(), req, &out, deps); err != nil {
+		t.Fatalf("handleTXFER: %v", err)
+	}
+	return out.String()
+}
+
+// runSYNCTest runs SYNC with the given old manifest body and returns parsed entries + RM paths.
+// RM fileIDs in the server response are resolved to paths using oldManifest.
+func runSYNCTest(t *testing.T, root string, oldManifest string) ([]encoding.ManifestEntry, []string) {
+	t.Helper()
+
+	// Build ID→path index from old manifest for RM resolution.
+	oldByID := buildOldByID(oldManifest)
+
+	// Build SYNC request.
+	reqRaw := fmt.Sprintf(`SYNC %q mode=fast link-mbps=1000 concurrency=8`, root)
+	req, err := ParseRequest([]byte(reqRaw))
+	if err != nil {
+		t.Fatalf("ParseRequest: %v", err)
+	}
+
+	// Create input: old manifest body + blank line.
+	var input bytes.Buffer
+	input.WriteString(oldManifest)
+	if oldManifest != "" && !strings.HasSuffix(oldManifest, "\n") {
+		input.WriteByte('\n')
+	}
+	input.WriteByte('\n') // blank line terminator
+
+	deps := &syncTestDeps{}
+	var out bytes.Buffer
+	if err := handleSYNCWithInput(context.Background(), req, &input, &out, deps); err != nil {
+		t.Fatalf("handleSYNCWithInput: %v", err)
+	}
+
+	return parseSYNCResponse(t, out.String(), oldByID)
+}
+
+// buildOldByID parses a raw FM/2 manifest and returns a fileID→path map.
+func buildOldByID(rawManifest string) map[uint64]string {
+	entries, _ := parseSYNCResponseEntries(rawManifest, nil)
+	m := make(map[uint64]string, len(entries))
+	for _, e := range entries {
+		m[e.ID] = e.Path
+	}
+	return m
+}
+
+// parseSYNCResponse parses the SYNC output into manifest entries and RM paths.
+// oldByID maps old manifest fileIDs to paths for RM resolution.
+func parseSYNCResponse(t *testing.T, raw string, oldByID map[uint64]string) ([]encoding.ManifestEntry, []string) {
+	t.Helper()
+	entries, rmIDs := parseSYNCResponseEntries(raw, nil)
+	rmPaths := make([]string, 0, len(rmIDs))
+	for _, id := range rmIDs {
+		path, ok := oldByID[id]
+		if !ok {
+			t.Fatalf("RM fileID %d not in old manifest", id)
+		}
+		rmPaths = append(rmPaths, path)
+	}
+	return entries, rmPaths
+}
+
+func manifestPaths(entries []encoding.ManifestEntry) []string {
+	paths := make([]string, len(entries))
+	for i, e := range entries {
+		paths[i] = e.Path
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// --- Fuzz test ---
+
+func FuzzSync(f *testing.F) {
+	f.Add([]byte{0})
+	f.Add([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	f.Add([]byte{0xFF, 0x01, 0x80, 0x42, 0x10, 0x99, 0xAB, 0xCD, 0xEF, 0x12})
+
+	f.Fuzz(func(t *testing.T, seed []byte) {
+		rng := deterministicRNG(seed)
+		tmpDir := t.TempDir()
+
+		// Round 1: Create initial files and get manifest via TXFER.
+		numFiles := rng.Intn(101) // 0-100
+		files := fuzzCreateRandomFiles(t, tmpDir, numFiles, rng)
+
+		oldManifest := runTXFERTest(t, tmpDir)
+		if oldManifest == "" && numFiles > 0 {
+			t.Fatal("expected non-empty manifest")
+		}
+
+		// Round 2: Modify filesystem and run SYNC.
+		fuzzApplyRandomModifications(t, tmpDir, &files, rng)
+
+		newEntries, rmPaths := runSYNCTest(t, tmpDir, oldManifest)
+		fuzzVerifySyncResult(t, tmpDir, oldManifest, newEntries, rmPaths)
+
+		// Round 3: Chain — use SYNC result as old manifest, modify again, SYNC again.
+		if len(newEntries) == 0 {
+			return
+		}
+		chainManifest := fuzzBuildManifestFromEntries(t, tmpDir, newEntries)
+		fuzzApplyRandomModifications(t, tmpDir, &files, rng)
+		newEntries2, rmPaths2 := runSYNCTest(t, tmpDir, chainManifest)
+		fuzzVerifySyncResult(t, tmpDir, chainManifest, newEntries2, rmPaths2)
+	})
+}
+
+func deterministicRNG(seed []byte) *rand.Rand {
+	var s int64
+	if len(seed) >= 8 {
+		s = int64(binary.LittleEndian.Uint64(seed[:8]))
+	} else {
+		for i, b := range seed {
+			s |= int64(b) << (uint(i) * 8)
+		}
+	}
+	return rand.New(rand.NewSource(s))
+}
+
+func fuzzCreateRandomFiles(t *testing.T, dir string, n int, rng *rand.Rand) []string {
+	t.Helper()
+	files := make([]string, 0, n)
+	for i := range n {
+		rel := fmt.Sprintf("file_%04d.dat", i)
+		if rng.Intn(3) == 0 {
+			rel = fmt.Sprintf("sub%d/file_%04d.dat", rng.Intn(5), i)
+		}
+		size := fuzzRandomFileSize(rng)
+		data := make([]byte, size)
+		rng.Read(data)
+		writeTestFile(t, dir, rel, string(data))
+		files = append(files, rel)
+	}
+	return files
+}
+
+func fuzzRandomFileSize(rng *rand.Rand) int {
+	switch rng.Intn(5) {
+	case 0:
+		return 0
+	case 1:
+		return 1
+	case 2:
+		return 64 + rng.Intn(4000)
+	case 3:
+		return 4096 + rng.Intn(60000)
+	default:
+		return 64*1024 + rng.Intn(192*1024)
+	}
+}
+
+func fuzzApplyRandomModifications(t *testing.T, dir string, files *[]string, rng *rand.Rand) {
+	t.Helper()
+	// Remove some files (0-30%).
+	var kept []string
+	for _, f := range *files {
+		if rng.Intn(100) < 30 {
+			os.Remove(filepath.Join(dir, f))
+		} else {
+			kept = append(kept, f)
+		}
+	}
+	// Change some files (0-20%).
+	for _, f := range kept {
+		if rng.Intn(100) < 20 {
+			size := fuzzRandomFileSize(rng)
+			data := make([]byte, size)
+			rng.Read(data)
+			writeTestFile(t, dir, f, string(data))
+		}
+	}
+	// Add new files (0-20).
+	numNew := rng.Intn(21)
+	base := len(kept) + 1000
+	for i := range numNew {
+		rel := fmt.Sprintf("new_%04d.dat", base+i)
+		if rng.Intn(3) == 0 {
+			rel = fmt.Sprintf("newsub%d/new_%04d.dat", rng.Intn(3), base+i)
+		}
+		size := fuzzRandomFileSize(rng)
+		data := make([]byte, size)
+		rng.Read(data)
+		writeTestFile(t, dir, rel, string(data))
+		kept = append(kept, rel)
+	}
+	*files = kept
+}
+
+func fuzzVerifySyncResult(t *testing.T, dir string, oldManifestRaw string, newEntries []encoding.ManifestEntry, rmPaths []string) {
+	t.Helper()
+
+	// Walk the filesystem to get ground truth.
+	onDisk := make(map[string]struct{})
+	filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		onDisk[filepath.ToSlash(rel)] = struct{}{}
+		return nil
+	})
+
+	// Every file on disk must appear in newEntries.
+	inManifest := make(map[string]struct{}, len(newEntries))
+	for _, e := range newEntries {
+		inManifest[e.Path] = struct{}{}
+	}
+	for path := range onDisk {
+		if _, ok := inManifest[path]; !ok {
+			t.Errorf("file on disk %q not in new manifest", path)
+		}
+	}
+	// Every new manifest entry must exist on disk.
+	for _, e := range newEntries {
+		if _, ok := onDisk[e.Path]; !ok {
+			t.Errorf("manifest entry %q not on disk", e.Path)
+		}
+		// Verify size matches.
+		info, err := os.Stat(filepath.Join(dir, filepath.FromSlash(e.Path)))
+		if err != nil {
+			t.Errorf("stat %q: %v", e.Path, err)
+			continue
+		}
+		if info.Size() != e.Size {
+			t.Errorf("size mismatch for %q: manifest=%d disk=%d", e.Path, e.Size, info.Size())
+		}
+	}
+
+	// Parse old manifest paths.
+	oldPaths := make(map[string]struct{})
+	if oldManifestRaw != "" {
+		oldEntries, _ := parseSYNCResponseEntries(oldManifestRaw, nil)
+		for _, e := range oldEntries {
+			oldPaths[e.Path] = struct{}{}
+		}
+	}
+
+	// rmPaths must be exactly: old paths not on disk.
+	rmSet := make(map[string]struct{}, len(rmPaths))
+	for _, p := range rmPaths {
+		if _, dup := rmSet[p]; dup {
+			t.Errorf("duplicate RM path: %q", p)
+		}
+		rmSet[p] = struct{}{}
+	}
+	for oldPath := range oldPaths {
+		_, stillOnDisk := onDisk[oldPath]
+		_, inRM := rmSet[oldPath]
+		if !stillOnDisk && !inRM {
+			t.Errorf("old path %q not on disk and not in RM", oldPath)
+		}
+		if stillOnDisk && inRM {
+			t.Errorf("old path %q still on disk but in RM", oldPath)
+		}
+	}
+	for rmPath := range rmSet {
+		if _, ok := oldPaths[rmPath]; !ok {
+			t.Errorf("RM path %q not in old manifest", rmPath)
+		}
+	}
+}
+
+// parseSYNCResponseEntries is a non-fatal version for fuzz/helper use.
+// Returns manifest entries and raw RM fileIDs (caller resolves IDs to paths).
+// oldByID is unused here but accepted for API symmetry with parseSYNCResponse.
+func parseSYNCResponseEntries(raw string, _ map[uint64]string) ([]encoding.ManifestEntry, []uint64) {
+	var entries []encoding.ManifestEntry
+	var rmIDs []uint64
+	prevPath := ""
+	prevMtime := ""
+	seenHeader := false
+
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "FM/2 ") {
+			seenHeader = true
+			prevPath = ""
+			prevMtime = ""
+			continue
+		}
+		if strings.HasPrefix(trimmed, "RM ") {
+			id, err := strconv.ParseUint(trimmed[3:], 10, 64)
+			if err == nil {
+				rmIDs = append(rmIDs, id)
+			}
+			continue
+		}
+		if !seenHeader {
+			continue
+		}
+		entry, nextPath, nextMtime, err := encoding.ParseManifestEntry(trimmed, prevPath, prevMtime)
+		if err != nil {
+			continue
+		}
+		entries = append(entries, entry)
+		prevPath = nextPath
+		prevMtime = nextMtime
+	}
+	return entries, rmIDs
+}
+
+// fuzzBuildManifestFromEntries creates a raw FM/2 manifest string from entries.
+func fuzzBuildManifestFromEntries(t *testing.T, root string, entries []encoding.ManifestEntry) string {
+	t.Helper()
+	var b strings.Builder
+	hdr := encoding.FormatManifestHeader(encoding.ManifestHeader{
+		TransferID:  "fuzz-tx",
+		Root:        root,
+		Mode:        "fast",
+		LinkMbps:    1000,
+		Concurrency: 8,
+	})
+	b.WriteString(hdr)
+	b.WriteByte('\n')
+	prevPath := ""
+	prevMtime := ""
+	for _, e := range entries {
+		line, nextPath, nextMtime, err := encoding.MarshalManifestEntry(e, prevPath, prevMtime)
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+		prevPath = nextPath
+		prevMtime = nextMtime
+	}
+	return b.String()
+}

--- a/server/internal/filexfer/ftcp/txfer.go
+++ b/server/internal/filexfer/ftcp/txfer.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/jolynch/pinch/utils"
+	"github.com/jolynch/pinch/internal/filexfer/encoding"
 	"github.com/zeebo/xxh3"
 )
 
@@ -214,10 +214,16 @@ func encodeManifest(
 		}
 		entryPath := filepath.ToSlash(rel)
 		entryMtime := strconv.FormatInt(info.ModTime().UnixNano(), 10)
-		entryMode := formatManifestMode(info.Mode())
+		entryMode := encoding.FormatManifestMode(info.Mode())
 
-		pathToken := frontToken(prevPath, entryPath, verbose)
-		mtimeToken := mtimeFrontToken(prevMtime, entryMtime, verbose)
+		prevP := prevPath
+		prevM := prevMtime
+		if verbose {
+			prevP = ""
+			prevM = ""
+		}
+		pathToken := encoding.EncodePathToken(prevP, entryPath)
+		mtimeToken, _ := encoding.EncodeMtimeToken(prevM, entryMtime)
 		line := fmt.Sprintf("%d %d %s %s %s\n", fileID, info.Size(), mtimeToken, entryMode, pathToken)
 
 		if maxChunkSize > 0 && chunkBytes+len(line) > maxChunkSize {
@@ -230,8 +236,8 @@ func encodeManifest(
 			if err := startChunk(); err != nil {
 				return err
 			}
-			pathToken = frontToken("", entryPath, verbose)
-			mtimeToken = mtimeFrontToken("", entryMtime, verbose)
+			pathToken = encoding.EncodePathToken("", entryPath)
+			mtimeToken, _ = encoding.EncodeMtimeToken("", entryMtime)
 			line = fmt.Sprintf("%d %d %s %s %s\n", fileID, info.Size(), mtimeToken, entryMode, pathToken)
 			if chunkBytes+len(line) > maxChunkSize {
 				return errors.New("max-manifest-chunk-size is too small for manifest entry")
@@ -270,25 +276,3 @@ func isBrokenPipe(err error) bool {
 		errors.Is(err, syscall.ECONNRESET)
 }
 
-func frontToken(prev string, curr string, verbose bool) string {
-	prefix := 0
-	if !verbose {
-		prefix = utils.CommonPrefixLen(prev, curr)
-	}
-	suffix := curr[prefix:]
-	return fmt.Sprintf("%d:%d:%s", prefix, len(suffix), suffix)
-}
-
-func mtimeFrontToken(prev string, curr string, verbose bool) string {
-	prefix := 0
-	if !verbose {
-		prefix = utils.CommonPrefixLen(prev, curr)
-	}
-	suffix := curr[prefix:]
-	return fmt.Sprintf("%d:%s", prefix, suffix)
-}
-
-func formatManifestMode(mode os.FileMode) string {
-	bits := mode.Perm() | (mode & (os.ModeSetuid | os.ModeSetgid | os.ModeSticky))
-	return fmt.Sprintf("%04o", bits)
-}

--- a/server/internal/filexfer/ftcp/verb.go
+++ b/server/internal/filexfer/ftcp/verb.go
@@ -16,6 +16,7 @@ const (
 	VerbCXSUM
 	VerbSTATUS
 	VerbPROBE
+	VerbSYNC
 )
 
 func ParseVerb(token string) (Verb, error) {
@@ -34,6 +35,8 @@ func ParseVerb(token string) (Verb, error) {
 		return VerbSTATUS, nil
 	case "PROBE":
 		return VerbPROBE, nil
+	case "SYNC":
+		return VerbSYNC, nil
 	default:
 		return VerbUnknown, fmt.Errorf("unknown verb: %s", token)
 	}

--- a/server/internal/filexfer/store/store.go
+++ b/server/internal/filexfer/store/store.go
@@ -36,21 +36,21 @@ const (
 )
 
 type Transfer struct {
-	ID        string
-	Directory string
-	Mode      string
-	LinkMbps  int64
+	ID          string
+	Directory   string
+	Mode        string
+	LinkMbps    int64
 	Concurrency int
-	NumFiles  int
-	TotalSize int64
-	Done      uint64
-	DoneSize  int64
-	State     []uint8
-	PathHash  []xxh3.Uint128
-	FileSize  []int64
-	AckedSize []int64
-	CreatedAt time.Time
-	ExpiresAt time.Time
+	NumFiles    int
+	TotalSize   int64
+	Done        uint64
+	DoneSize    int64
+	State       []uint8
+	PathHash    []xxh3.Uint128
+	FileSize    []int64
+	AckedSize   []int64
+	CreatedAt   time.Time
+	ExpiresAt   time.Time
 }
 
 type TransferFileState struct {
@@ -84,16 +84,17 @@ func (e *FileLookupError) Error() string {
 	return e.Msg
 }
 
-type transferStore struct {
+type managedTransfer struct {
 	mu           sync.RWMutex
-	transfers    map[string]Transfer
-	fileHashes   map[fileHashKey]fileHashState
+	deleted      bool
+	transfer     Transfer
+	fileHashes   map[uint64]fileHashState
 	windowHashes map[windowHashKey]*windowHashState
 }
 
-type fileHashKey struct {
-	txferID string
-	fileID  uint64
+type transferStore struct {
+	mu        sync.RWMutex
+	transfers map[string]*managedTransfer
 }
 
 type fileHashState struct {
@@ -108,8 +109,7 @@ type fileHashState struct {
 }
 
 type windowHashKey struct {
-	txferID string
-	fileID  uint64
+	fileID   uint64
 	endBytes int64
 }
 
@@ -136,8 +136,14 @@ func init() {
 
 func newTransferStore() *transferStore {
 	return &transferStore{
-		transfers:    make(map[string]Transfer),
-		fileHashes:   make(map[fileHashKey]fileHashState),
+		transfers: make(map[string]*managedTransfer),
+	}
+}
+
+func newManagedTransfer(transfer Transfer) *managedTransfer {
+	return &managedTransfer{
+		transfer:     transfer,
+		fileHashes:   make(map[uint64]fileHashState),
 		windowHashes: make(map[windowHashKey]*windowHashState),
 	}
 }
@@ -146,44 +152,65 @@ func shouldAdvanceState(current uint8, next uint8) bool {
 	return next >= current
 }
 
+func cloneTransfer(transfer Transfer) Transfer {
+	out := transfer
+	out.State = append([]uint8(nil), transfer.State...)
+	out.PathHash = append([]xxh3.Uint128(nil), transfer.PathHash...)
+	out.FileSize = append([]int64(nil), transfer.FileSize...)
+	out.AckedSize = append([]int64(nil), transfer.AckedSize...)
+	return out
+}
+
+func (s *transferStore) getManagedTransfer(txferID string) (*managedTransfer, bool) {
+	s.mu.RLock()
+	managed, ok := s.transfers[txferID]
+	s.mu.RUnlock()
+	return managed, ok
+}
+
 func (s *transferStore) create(transfer Transfer) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, exists := s.transfers[transfer.ID]; exists {
 		return false
 	}
-	s.transfers[transfer.ID] = transfer
+	s.transfers[transfer.ID] = newManagedTransfer(transfer)
 	return true
 }
 
 func (s *transferStore) setState(txferID string, state uint8) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	for i := range transfer.State {
-		if shouldAdvanceState(transfer.State[i], state) {
-			transfer.State[i] = state
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+	for i := range managed.transfer.State {
+		if shouldAdvanceState(managed.transfer.State[i], state) {
+			managed.transfer.State[i] = state
 		}
 	}
-	s.transfers[txferID] = transfer
 	return true
 }
 
 func (s *transferStore) setTransferHints(txferID string, mode string, linkMbps int64, concurrency int) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	transfer.Mode = strings.ToLower(strings.TrimSpace(mode))
-	transfer.LinkMbps = linkMbps
-	transfer.Concurrency = concurrency
-	s.transfers[txferID] = transfer
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+	managed.transfer.Mode = strings.ToLower(strings.TrimSpace(mode))
+	managed.transfer.LinkMbps = linkMbps
+	managed.transfer.Concurrency = concurrency
 	return true
 }
 
@@ -191,26 +218,29 @@ func (s *transferStore) appendFileStates(txferID string, updates []TransferFileS
 	if len(updates) == 0 {
 		return
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return
 	}
 
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return
+	}
+
 	ensureLen := func(n int) {
-		if n <= len(transfer.State) {
+		if n <= len(managed.transfer.State) {
 			return
 		}
-		oldLen := len(transfer.State)
+		oldLen := len(managed.transfer.State)
 		growBy := n - oldLen
-		transfer.State = append(transfer.State, make([]uint8, growBy)...)
-		transfer.PathHash = append(transfer.PathHash, make([]xxh3.Uint128, growBy)...)
-		transfer.FileSize = append(transfer.FileSize, make([]int64, growBy)...)
-		transfer.AckedSize = append(transfer.AckedSize, make([]int64, growBy)...)
+		managed.transfer.State = append(managed.transfer.State, make([]uint8, growBy)...)
+		managed.transfer.PathHash = append(managed.transfer.PathHash, make([]xxh3.Uint128, growBy)...)
+		managed.transfer.FileSize = append(managed.transfer.FileSize, make([]int64, growBy)...)
+		managed.transfer.AckedSize = append(managed.transfer.AckedSize, make([]int64, growBy)...)
 		for i := oldLen; i < n; i++ {
-			transfer.State[i] = TransferStateStarted
+			managed.transfer.State[i] = TransferStateStarted
 		}
 	}
 
@@ -218,33 +248,35 @@ func (s *transferStore) appendFileStates(txferID string, updates []TransferFileS
 		idx := int(update.FileID)
 		ensureLen(idx + 1)
 
-		if idx+1 > transfer.NumFiles {
-			transfer.NumFiles = idx + 1
+		if idx+1 > managed.transfer.NumFiles {
+			managed.transfer.NumFiles = idx + 1
 		}
 
-		transfer.TotalSize += update.FileSize - transfer.FileSize[idx]
-		transfer.FileSize[idx] = update.FileSize
-		transfer.PathHash[idx] = update.PathHash
-		if shouldAdvanceState(transfer.State[idx], state) {
-			transfer.State[idx] = state
+		managed.transfer.TotalSize += update.FileSize - managed.transfer.FileSize[idx]
+		managed.transfer.FileSize[idx] = update.FileSize
+		managed.transfer.PathHash[idx] = update.PathHash
+		if shouldAdvanceState(managed.transfer.State[idx], state) {
+			managed.transfer.State[idx] = state
 		}
 	}
-	s.transfers[txferID] = transfer
 }
 
 func (s *transferStore) appendFileHashChunk(txferID string, fileID uint64, offset int64, chunk []byte) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	if fileID >= uint64(len(transfer.State)) || offset < 0 {
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
 		return false
 	}
-	key := fileHashKey{txferID: txferID, fileID: fileID}
-	state, exists := s.fileHashes[key]
+	if fileID >= uint64(len(managed.transfer.State)) || offset < 0 {
+		return false
+	}
+
+	state, exists := managed.fileHashes[fileID]
 	if !exists || offset == 0 {
 		state = fileHashState{
 			hasher:    xxh3.New128(),
@@ -254,13 +286,13 @@ func (s *transferStore) appendFileHashChunk(txferID string, fileID uint64, offse
 	}
 	if !state.valid || state.finalized {
 		state.expiresAt = time.Now().Add(ttl)
-		s.fileHashes[key] = state
+		managed.fileHashes[fileID] = state
 		return true
 	}
 	if offset != state.hashedSize {
 		state.valid = false
 		state.expiresAt = time.Now().Add(ttl)
-		s.fileHashes[key] = state
+		managed.fileHashes[fileID] = state
 		return true
 	}
 
@@ -268,23 +300,29 @@ func (s *transferStore) appendFileHashChunk(txferID string, fileID uint64, offse
 		if _, err := state.hasher.Write(chunk); err != nil {
 			state.valid = false
 			state.expiresAt = time.Now().Add(ttl)
-			s.fileHashes[key] = state
+			managed.fileHashes[fileID] = state
 			return true
 		}
 	}
 	state.hashedSize += int64(len(chunk))
 	state.hashToken = ""
 	state.expiresAt = time.Now().Add(ttl)
-	s.fileHashes[key] = state
+	managed.fileHashes[fileID] = state
 	return true
 }
 
 func (s *transferStore) finalizeFileHash(txferID string, fileID uint64) (string, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return "", false
+	}
 
-	key := fileHashKey{txferID: txferID, fileID: fileID}
-	state, ok := s.fileHashes[key]
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return "", false
+	}
+	state, ok := managed.fileHashes[fileID]
 	if !ok || !state.valid || state.hasher == nil {
 		return "", false
 	}
@@ -292,16 +330,22 @@ func (s *transferStore) finalizeFileHash(txferID string, fileID uint64) (string,
 	state.finalized = true
 	state.hasher = nil
 	state.expiresAt = time.Now().Add(ttl)
-	s.fileHashes[key] = state
+	managed.fileHashes[fileID] = state
 	return state.hashToken, true
 }
 
 func (s *transferStore) getFileCompressionMode(txferID string, fileID uint64) (CompressionMode, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return CompressionModeLz4, false
+	}
 
-	key := fileHashKey{txferID: txferID, fileID: fileID}
-	state, ok := s.fileHashes[key]
+	managed.mu.RLock()
+	defer managed.mu.RUnlock()
+	if managed.deleted {
+		return CompressionModeLz4, false
+	}
+	state, ok := managed.fileHashes[fileID]
 	if !ok || !state.hasLatestComp {
 		return CompressionModeLz4, false
 	}
@@ -309,11 +353,18 @@ func (s *transferStore) getFileCompressionMode(txferID string, fileID uint64) (C
 }
 
 func (s *transferStore) setFileCompressionMode(txferID string, fileID uint64, mode CompressionMode) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return false
+	}
 
-	key := fileHashKey{txferID: txferID, fileID: fileID}
-	state, ok := s.fileHashes[key]
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+
+	state, ok := managed.fileHashes[fileID]
 	if !ok {
 		state = fileHashState{
 			hasher:    xxh3.New128(),
@@ -324,16 +375,23 @@ func (s *transferStore) setFileCompressionMode(txferID string, fileID uint64, mo
 	state.latestComp = uint8(mode)
 	state.hasLatestComp = true
 	state.expiresAt = time.Now().Add(ttl)
-	s.fileHashes[key] = state
+	managed.fileHashes[fileID] = state
 	return true
 }
 
 func (s *transferStore) verifyFileHashToken(txferID string, fileID uint64, expectedBytes int64, token string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return false
+	}
 
-	key := fileHashKey{txferID: txferID, fileID: fileID}
-	state, ok := s.fileHashes[key]
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+
+	state, ok := managed.fileHashes[fileID]
 	if !ok || !state.valid || !state.finalized {
 		return false
 	}
@@ -345,57 +403,55 @@ func (s *transferStore) verifyFileHashToken(txferID string, fileID uint64, expec
 	if expectedToken == "" || expectedToken != actualToken {
 		return false
 	}
-	delete(s.fileHashes, key)
+	delete(managed.fileHashes, fileID)
 	return true
 }
 
 func (s *transferStore) delete(txferID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.transfers[txferID]; !ok {
+
+	managed, ok := s.transfers[txferID]
+	if !ok {
 		return false
 	}
+	managed.mu.Lock()
+	managed.deleted = true
+	managed.mu.Unlock()
 	delete(s.transfers, txferID)
-	for key := range s.fileHashes {
-		if key.txferID == txferID {
-			delete(s.fileHashes, key)
-		}
-	}
-	for key := range s.windowHashes {
-		if key.txferID == txferID {
-			delete(s.windowHashes, key)
-		}
-	}
 	return true
 }
 
 func (s *transferStore) get(txferID string) (Transfer, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return Transfer{}, false
 	}
-	out := transfer
-	out.State = append([]uint8(nil), transfer.State...)
-	out.PathHash = append([]xxh3.Uint128(nil), transfer.PathHash...)
-	out.FileSize = append([]int64(nil), transfer.FileSize...)
-	out.AckedSize = append([]int64(nil), transfer.AckedSize...)
-	return out, true
+
+	managed.mu.RLock()
+	defer managed.mu.RUnlock()
+	if managed.deleted {
+		return Transfer{}, false
+	}
+	return cloneTransfer(managed.transfer), true
 }
 
 func (s *transferStore) getFileStates(txferID string) ([]TransferFileState, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return nil, false
 	}
-	states := make([]TransferFileState, len(transfer.State))
-	for i := range transfer.State {
+
+	managed.mu.RLock()
+	defer managed.mu.RUnlock()
+	if managed.deleted {
+		return nil, false
+	}
+	states := make([]TransferFileState, len(managed.transfer.State))
+	for i := range managed.transfer.State {
 		states[i] = TransferFileState{
-			State:    transfer.State[i],
-			PathHash: transfer.PathHash[i],
+			State:    managed.transfer.State[i],
+			PathHash: managed.transfer.PathHash[i],
 		}
 	}
 	return states, true
@@ -407,20 +463,24 @@ func (s *transferStore) resolveFileRef(txferID string, fileID uint64, fullPathRa
 		return FileRef{}, &FileLookupError{Code: http.StatusBadRequest, Msg: "path must be absolute"}
 	}
 
-	s.mu.RLock()
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
-		s.mu.RUnlock()
 		return FileRef{}, &FileLookupError{Code: http.StatusNotFound, Msg: "transfer not found"}
 	}
-	if fileID >= uint64(len(transfer.State)) {
-		s.mu.RUnlock()
+
+	managed.mu.RLock()
+	if managed.deleted {
+		managed.mu.RUnlock()
+		return FileRef{}, &FileLookupError{Code: http.StatusNotFound, Msg: "transfer not found"}
+	}
+	if fileID >= uint64(len(managed.transfer.State)) {
+		managed.mu.RUnlock()
 		return FileRef{}, &FileLookupError{Code: http.StatusNotFound, Msg: "file id out of range"}
 	}
-	directory := transfer.Directory
-	expectedDigest := transfer.PathHash[fileID]
-	fileSize := transfer.FileSize[fileID]
-	s.mu.RUnlock()
+	directory := managed.transfer.Directory
+	expectedDigest := managed.transfer.PathHash[fileID]
+	fileSize := managed.transfer.FileSize[fileID]
+	managed.mu.RUnlock()
 
 	if !pathWithinRoot(directory, fullPath) {
 		return FileRef{}, &FileLookupError{Code: http.StatusForbidden, Msg: "path must be within transfer root"}
@@ -442,9 +502,7 @@ func (s *transferStore) resolveFileRef(txferID string, fileID uint64, fullPathRa
 
 func (s *transferStore) resetForTest() {
 	s.mu.Lock()
-	s.transfers = make(map[string]Transfer)
-	s.fileHashes = make(map[fileHashKey]fileHashState)
-	s.windowHashes = make(map[windowHashKey]*windowHashState)
+	s.transfers = make(map[string]*managedTransfer)
 	s.mu.Unlock()
 }
 
@@ -456,75 +514,101 @@ func (s *transferStore) countForTest() int {
 
 func (s *transferStore) listForTest() []Transfer {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	out := make([]Transfer, 0, len(s.transfers))
-	for _, transfer := range s.transfers {
-		copyTransfer := transfer
-		copyTransfer.State = append([]uint8(nil), transfer.State...)
-		copyTransfer.PathHash = append([]xxh3.Uint128(nil), transfer.PathHash...)
-		copyTransfer.FileSize = append([]int64(nil), transfer.FileSize...)
-		copyTransfer.AckedSize = append([]int64(nil), transfer.AckedSize...)
-		out = append(out, copyTransfer)
+	transfers := make([]*managedTransfer, 0, len(s.transfers))
+	for _, managed := range s.transfers {
+		transfers = append(transfers, managed)
+	}
+	s.mu.RUnlock()
+
+	out := make([]Transfer, 0, len(transfers))
+	for _, managed := range transfers {
+		managed.mu.RLock()
+		if !managed.deleted {
+			out = append(out, cloneTransfer(managed.transfer))
+		}
+		managed.mu.RUnlock()
 	}
 	return out
 }
 
 func (s *transferStore) setFileState(txferID string, fileID uint64, state uint8) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	if fileID >= uint64(len(transfer.State)) {
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+	if fileID >= uint64(len(managed.transfer.State)) {
 		return false
 	}
 	idx := int(fileID)
-	if shouldAdvanceState(transfer.State[idx], state) {
-		transfer.State[idx] = state
+	if !shouldAdvanceState(managed.transfer.State[idx], state) || managed.transfer.State[idx] == state {
+		return true
 	}
-	s.transfers[txferID] = transfer
+	managed.transfer.State[idx] = state
 	return true
 }
 
 func (s *transferStore) acknowledgeFiles(entries []AckEntry) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	ok := true
-	for _, e := range entries {
-		if !s.acknowledgeFileLocked(e.TxferID, e.FileID, e.AckBytes) {
-			ok = false
+	grouped := make(map[string][]AckEntry)
+	order := make([]string, 0)
+	for _, entry := range entries {
+		if _, ok := grouped[entry.TxferID]; !ok {
+			order = append(order, entry.TxferID)
 		}
+		grouped[entry.TxferID] = append(grouped[entry.TxferID], entry)
+	}
+
+	ok := true
+	for _, txferID := range order {
+		managed, found := s.getManagedTransfer(txferID)
+		if !found {
+			ok = false
+			continue
+		}
+
+		managed.mu.Lock()
+		if managed.deleted {
+			managed.mu.Unlock()
+			ok = false
+			continue
+		}
+		for _, entry := range grouped[txferID] {
+			if !s.acknowledgeFileLocked(managed, entry.FileID, entry.AckBytes) {
+				ok = false
+			}
+		}
+		managed.mu.Unlock()
 	}
 	return ok
 }
 
-func (s *transferStore) acknowledgeFileLocked(txferID string, fileID uint64, ackBytes int64) bool {
-	transfer, ok := s.transfers[txferID]
-	if !ok {
+func (s *transferStore) acknowledgeFileLocked(managed *managedTransfer, fileID uint64, ackBytes int64) bool {
+	if managed == nil || managed.deleted {
 		return false
 	}
-	if fileID >= uint64(len(transfer.State)) {
+	if fileID >= uint64(len(managed.transfer.State)) {
 		return false
 	}
 	idx := int(fileID)
-	currentState := transfer.State[idx]
+	currentState := managed.transfer.State[idx]
 
 	if currentState == TransferStateMissing {
-		s.transfers[txferID] = transfer
 		return true
 	}
 
 	if ackBytes == -1 {
 		if shouldAdvanceState(currentState, TransferStateMissing) {
 			wasTerminal := currentState == TransferStateDone || currentState == TransferStateMissing
-			transfer.State[idx] = TransferStateMissing
+			managed.transfer.State[idx] = TransferStateMissing
 			if !wasTerminal {
-				transfer.Done++
+				managed.transfer.Done++
 			}
 		}
-		s.transfers[txferID] = transfer
 		return true
 	}
 
@@ -532,7 +616,7 @@ func (s *transferStore) acknowledgeFileLocked(txferID string, fileID uint64, ack
 	if target < 0 {
 		target = 0
 	}
-	maxAck := transfer.FileSize[idx]
+	maxAck := managed.transfer.FileSize[idx]
 	if maxAck < 0 {
 		maxAck = 0
 	}
@@ -540,44 +624,41 @@ func (s *transferStore) acknowledgeFileLocked(txferID string, fileID uint64, ack
 		target = maxAck
 	}
 
-	prev := transfer.AckedSize[idx]
+	prev := managed.transfer.AckedSize[idx]
 	if target <= prev {
-		s.transfers[txferID] = transfer
 		return true
 	}
 
 	delta := target - prev
-	transfer.AckedSize[idx] = target
-	transfer.DoneSize += delta
+	managed.transfer.AckedSize[idx] = target
+	managed.transfer.DoneSize += delta
 
 	if prev < maxAck && target == maxAck {
-		transfer.Done++
-		if shouldAdvanceState(transfer.State[idx], TransferStateDone) {
-			transfer.State[idx] = TransferStateDone
+		managed.transfer.Done++
+		if shouldAdvanceState(managed.transfer.State[idx], TransferStateDone) {
+			managed.transfer.State[idx] = TransferStateDone
 		}
 	}
 
-	s.transfers[txferID] = transfer
-
-	wKey := windowHashKey{txferID: txferID, fileID: fileID, endBytes: target}
-	delete(s.windowHashes, wKey)
+	delete(managed.windowHashes, windowHashKey{fileID: fileID, endBytes: target})
 	return true
 }
 
 func (s *transferStore) clipTransfer(txferID string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
 
-	transfer.State = slices.Clip(transfer.State)
-	transfer.PathHash = slices.Clip(transfer.PathHash)
-	transfer.FileSize = slices.Clip(transfer.FileSize)
-	transfer.AckedSize = slices.Clip(transfer.AckedSize)
-	s.transfers[txferID] = transfer
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+	managed.transfer.State = slices.Clip(managed.transfer.State)
+	managed.transfer.PathHash = slices.Clip(managed.transfer.PathHash)
+	managed.transfer.FileSize = slices.Clip(managed.transfer.FileSize)
+	managed.transfer.AckedSize = slices.Clip(managed.transfer.AckedSize)
 	return true
 }
 
@@ -591,30 +672,40 @@ func (s *transferStore) reapExpiredLoop() {
 
 	for now := range ticker.C {
 		s.mu.Lock()
-		for txferID, transfer := range s.transfers {
-			if !transfer.ExpiresAt.After(now) {
+		survivors := make([]*managedTransfer, 0, len(s.transfers))
+		for txferID, managed := range s.transfers {
+			managed.mu.RLock()
+			expired := !managed.deleted && !managed.transfer.ExpiresAt.After(now)
+			managed.mu.RUnlock()
+			if expired {
+				managed.mu.Lock()
+				managed.deleted = true
+				managed.mu.Unlock()
 				delete(s.transfers, txferID)
-			}
-		}
-		for key, state := range s.fileHashes {
-			if !state.expiresAt.After(now) {
-				delete(s.fileHashes, key)
 				continue
 			}
-			if _, ok := s.transfers[key.txferID]; !ok {
-				delete(s.fileHashes, key)
-			}
-		}
-		for key, ws := range s.windowHashes {
-			if !ws.expiresAt.After(now) {
-				delete(s.windowHashes, key)
-				continue
-			}
-			if _, ok := s.transfers[key.txferID]; !ok {
-				delete(s.windowHashes, key)
-			}
+			survivors = append(survivors, managed)
 		}
 		s.mu.Unlock()
+
+		for _, managed := range survivors {
+			managed.mu.Lock()
+			if managed.deleted {
+				managed.mu.Unlock()
+				continue
+			}
+			for fileID, state := range managed.fileHashes {
+				if !state.expiresAt.After(now) {
+					delete(managed.fileHashes, fileID)
+				}
+			}
+			for key, state := range managed.windowHashes {
+				if !state.expiresAt.After(now) {
+					delete(managed.windowHashes, key)
+				}
+			}
+			managed.mu.Unlock()
+		}
 	}
 }
 
@@ -632,41 +723,45 @@ func normalizeHashToken(raw string) string {
 }
 
 func (s *transferStore) setWindowHashToken(txferID string, fileID uint64, endBytes int64, token string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	transfer, ok := s.transfers[txferID]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	if fileID >= uint64(len(transfer.State)) || endBytes < 0 {
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return false
+	}
+	if fileID >= uint64(len(managed.transfer.State)) || endBytes < 0 {
 		return false
 	}
 	if !validHashToken(token) {
 		return false
 	}
-	key := windowHashKey{txferID: txferID, fileID: fileID, endBytes: endBytes}
-	ws := &windowHashState{
+	managed.windowHashes[windowHashKey{fileID: fileID, endBytes: endBytes}] = &windowHashState{
 		hashToken: normalizeHashToken(token),
 		expiresAt: time.Now().Add(ttl),
 	}
-	s.windowHashes[key] = ws
 	return true
 }
 
 func (s *transferStore) verifyWindowHashToken(txferID string, fileID uint64, endBytes int64, token string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if endBytes < 0 {
-		return false
-	}
-	key := windowHashKey{txferID: txferID, fileID: fileID, endBytes: endBytes}
-	ws, ok := s.windowHashes[key]
+	managed, ok := s.getManagedTransfer(txferID)
 	if !ok {
 		return false
 	}
-	return ws.hashToken == normalizeHashToken(token)
+
+	managed.mu.RLock()
+	defer managed.mu.RUnlock()
+	if managed.deleted || endBytes < 0 {
+		return false
+	}
+	state, ok := managed.windowHashes[windowHashKey{fileID: fileID, endBytes: endBytes}]
+	if !ok {
+		return false
+	}
+	return state.hashToken == normalizeHashToken(token)
 }
 
 func NewTransfer(directory string, numFiles int, totalSize int64) (Transfer, error) {
@@ -677,21 +772,21 @@ func NewTransfer(directory string, numFiles int, totalSize int64) (Transfer, err
 		}
 		now := time.Now()
 		transfer := Transfer{
-			ID:        txferID,
-			Directory: directory,
-			Mode:      "",
-			LinkMbps:  0,
+			ID:          txferID,
+			Directory:   directory,
+			Mode:        "",
+			LinkMbps:    0,
 			Concurrency: 0,
-			NumFiles:  numFiles,
-			TotalSize: totalSize,
-			Done:      0,
-			DoneSize:  0,
-			State:     make([]uint8, numFiles),
-			PathHash:  make([]xxh3.Uint128, numFiles),
-			FileSize:  make([]int64, numFiles),
-			AckedSize: make([]int64, numFiles),
-			CreatedAt: now,
-			ExpiresAt: now.Add(ttl),
+			NumFiles:    numFiles,
+			TotalSize:   totalSize,
+			Done:        0,
+			DoneSize:    0,
+			State:       make([]uint8, numFiles),
+			PathHash:    make([]xxh3.Uint128, numFiles),
+			FileSize:    make([]int64, numFiles),
+			AckedSize:   make([]int64, numFiles),
+			CreatedAt:   now,
+			ExpiresAt:   now.Add(ttl),
 		}
 		for i := range transfer.State {
 			transfer.State[i] = TransferStateStarted

--- a/server/internal/filexfer/store/store_test.go
+++ b/server/internal/filexfer/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -422,6 +423,189 @@ func TestWindowHashesTrackedPerEndOffset(t *testing.T) {
 	}
 }
 
+func TestDeleteTransferInvalidatesManagedTransfer(t *testing.T) {
+	resetTransferStore()
+
+	transfer, err := NewTransfer("/tmp/x", 1, 10)
+	if err != nil {
+		t.Fatalf("NewTransfer failed: %v", err)
+	}
+	RegisterTransferFileStates(transfer.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/x/0")), FileSize: 10},
+	}, TransferStateRunning)
+
+	managed, ok := manager.getManagedTransfer(transfer.ID)
+	if !ok {
+		t.Fatalf("expected managed transfer")
+	}
+	if ok := DeleteTransfer(transfer.ID); !ok {
+		t.Fatalf("DeleteTransfer returned false")
+	}
+	if _, ok := GetTransfer(transfer.ID); ok {
+		t.Fatalf("deleted transfer should not be visible")
+	}
+
+	managed.mu.RLock()
+	if !managed.deleted {
+		managed.mu.RUnlock()
+		t.Fatalf("expected managed transfer to be marked deleted")
+	}
+	managed.mu.RUnlock()
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if ok := manager.acknowledgeFileLocked(managed, 0, 4); ok {
+		t.Fatalf("expected stale managed transfer mutation to fail after delete")
+	}
+}
+
+func TestAcknowledgeTransferFilesMixedTransfers(t *testing.T) {
+	resetTransferStore()
+
+	first, err := NewTransfer("/tmp/a", 1, 10)
+	if err != nil {
+		t.Fatalf("NewTransfer first failed: %v", err)
+	}
+	second, err := NewTransfer("/tmp/b", 1, 12)
+	if err != nil {
+		t.Fatalf("NewTransfer second failed: %v", err)
+	}
+	RegisterTransferFileStates(first.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/a/0")), FileSize: 10},
+	}, TransferStateRunning)
+	RegisterTransferFileStates(second.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/b/0")), FileSize: 12},
+	}, TransferStateRunning)
+
+	firstToken := "xxh128:0000000000000000000000000000000a"
+	secondToken := "xxh128:0000000000000000000000000000000b"
+	if ok := SetTransferFileWindowHash(first.ID, 0, 6, firstToken); !ok {
+		t.Fatalf("SetTransferFileWindowHash first returned false")
+	}
+	if ok := SetTransferFileWindowHash(second.ID, 0, 8, secondToken); !ok {
+		t.Fatalf("SetTransferFileWindowHash second returned false")
+	}
+
+	if ok := AcknowledgeTransferFiles([]AckEntry{
+		{TxferID: first.ID, FileID: 0, AckBytes: 6},
+		{TxferID: second.ID, FileID: 0, AckBytes: 8},
+	}); !ok {
+		t.Fatalf("AcknowledgeTransferFiles returned false")
+	}
+
+	firstStored, ok := GetTransfer(first.ID)
+	if !ok {
+		t.Fatalf("first transfer not found")
+	}
+	if firstStored.DoneSize != 6 || firstStored.Done != 0 {
+		t.Fatalf("unexpected first counters: done=%d doneSize=%d", firstStored.Done, firstStored.DoneSize)
+	}
+	secondStored, ok := GetTransfer(second.ID)
+	if !ok {
+		t.Fatalf("second transfer not found")
+	}
+	if secondStored.DoneSize != 8 || secondStored.Done != 0 {
+		t.Fatalf("unexpected second counters: done=%d doneSize=%d", secondStored.Done, secondStored.DoneSize)
+	}
+	if VerifyTransferFileWindowHash(first.ID, 0, 6, firstToken) {
+		t.Fatalf("expected first window hash cleared after ack")
+	}
+	if VerifyTransferFileWindowHash(second.ID, 0, 8, secondToken) {
+		t.Fatalf("expected second window hash cleared after ack")
+	}
+}
+
+func TestWindowHashesAreTransferLocal(t *testing.T) {
+	resetTransferStore()
+
+	first, err := NewTransfer("/tmp/a", 1, 10)
+	if err != nil {
+		t.Fatalf("NewTransfer first failed: %v", err)
+	}
+	second, err := NewTransfer("/tmp/b", 1, 10)
+	if err != nil {
+		t.Fatalf("NewTransfer second failed: %v", err)
+	}
+	RegisterTransferFileStates(first.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/a/0")), FileSize: 10},
+	}, TransferStateRunning)
+	RegisterTransferFileStates(second.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/b/0")), FileSize: 10},
+	}, TransferStateRunning)
+
+	firstToken := "xxh128:0000000000000000000000000000000c"
+	secondToken := "xxh128:0000000000000000000000000000000d"
+	if ok := SetTransferFileWindowHash(first.ID, 0, 4, firstToken); !ok {
+		t.Fatalf("SetTransferFileWindowHash first returned false")
+	}
+	if ok := SetTransferFileWindowHash(second.ID, 0, 4, secondToken); !ok {
+		t.Fatalf("SetTransferFileWindowHash second returned false")
+	}
+	if !VerifyTransferFileWindowHash(first.ID, 0, 4, firstToken) {
+		t.Fatalf("expected first transfer window hash")
+	}
+	if !VerifyTransferFileWindowHash(second.ID, 0, 4, secondToken) {
+		t.Fatalf("expected second transfer window hash")
+	}
+
+	if ok := AcknowledgeTransferFile(first.ID, 0, 4); !ok {
+		t.Fatalf("AcknowledgeTransferFile first returned false")
+	}
+	if VerifyTransferFileWindowHash(first.ID, 0, 4, firstToken) {
+		t.Fatalf("expected first transfer window hash cleared")
+	}
+	if !VerifyTransferFileWindowHash(second.ID, 0, 4, secondToken) {
+		t.Fatalf("expected second transfer window hash to remain")
+	}
+}
+
+func TestGetTransferSnapshotsAreCopies(t *testing.T) {
+	resetTransferStore()
+
+	transfer, err := NewTransfer("/tmp/x", 1, 10)
+	if err != nil {
+		t.Fatalf("NewTransfer failed: %v", err)
+	}
+	RegisterTransferFileStates(transfer.ID, []TransferFileStateUpdate{
+		{FileID: 0, PathHash: xxh3.Hash128([]byte("/tmp/x/0")), FileSize: 10},
+	}, TransferStateRunning)
+
+	stored, ok := GetTransfer(transfer.ID)
+	if !ok {
+		t.Fatalf("GetTransfer returned not found")
+	}
+	stored.State[0] = TransferStateMissing
+	stored.PathHash[0] = xxh3.Hash128([]byte("mutated"))
+	stored.FileSize[0] = 999
+	stored.AckedSize[0] = 999
+
+	storedAgain, ok := GetTransfer(transfer.ID)
+	if !ok {
+		t.Fatalf("GetTransfer returned not found on second read")
+	}
+	if storedAgain.State[0] != TransferStateRunning {
+		t.Fatalf("expected original transfer state to remain running, got %d", storedAgain.State[0])
+	}
+	if storedAgain.FileSize[0] != 10 || storedAgain.AckedSize[0] != 0 {
+		t.Fatalf("expected original transfer sizes to remain unchanged")
+	}
+
+	states, ok := GetTransferFileStates(transfer.ID)
+	if !ok {
+		t.Fatalf("GetTransferFileStates returned not found")
+	}
+	states[0].State = TransferStateMissing
+	states[0].PathHash = xxh3.Hash128([]byte("mutated-again"))
+
+	statesAgain, ok := GetTransferFileStates(transfer.ID)
+	if !ok {
+		t.Fatalf("GetTransferFileStates returned not found on second read")
+	}
+	if statesAgain[0].State != TransferStateRunning {
+		t.Fatalf("expected wrapped state snapshot to be isolated, got %d", statesAgain[0].State)
+	}
+}
+
 func setupLookupFixture(t *testing.T, fileName string, content []byte) (string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -538,4 +722,50 @@ func TestGetFileSuccess(t *testing.T) {
 	if ref.FileSize != 5 {
 		t.Fatalf("unexpected ref size: %d", ref.FileSize)
 	}
+}
+
+func BenchmarkTransferStoreConcurrentHotPaths(b *testing.B) {
+	resetTransferStore()
+
+	const numTransfers = 32
+	const filesPerTransfer = 8
+	transferIDs := make([]string, 0, numTransfers)
+	for i := 0; i < numTransfers; i++ {
+		transfer, err := NewTransfer("/tmp/bench-"+strconv.Itoa(i), filesPerTransfer, int64(filesPerTransfer*1024))
+		if err != nil {
+			b.Fatalf("NewTransfer failed: %v", err)
+		}
+		updates := make([]TransferFileStateUpdate, 0, filesPerTransfer)
+		for fileID := 0; fileID < filesPerTransfer; fileID++ {
+			updates = append(updates, TransferFileStateUpdate{
+				FileID:   uint64(fileID),
+				PathHash: xxh3.Hash128([]byte(transfer.ID + "-" + strconv.Itoa(fileID))),
+				FileSize: 1024,
+			})
+		}
+		RegisterTransferFileStates(transfer.ID, updates, TransferStateRunning)
+		transferIDs = append(transferIDs, transfer.ID)
+	}
+
+	var counter atomic.Uint64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			n := counter.Add(1)
+			txferID := transferIDs[int(n)%len(transferIDs)]
+			fileID := uint64((n / uint64(len(transferIDs))) % filesPerTransfer)
+			endBytes := int64((n%8)+1) * 64
+			token := "xxh128:" + strconv.FormatUint(n, 16)
+
+			if !SetTransferFileState(txferID, fileID, TransferStateRunning) {
+				b.Fatalf("SetTransferFileState returned false")
+			}
+			if !SetTransferFileWindowHash(txferID, fileID, endBytes, token) {
+				b.Fatalf("SetTransferFileWindowHash returned false")
+			}
+			if !AcknowledgeTransferFiles([]AckEntry{{TxferID: txferID, FileID: fileID, AckBytes: endBytes}}) {
+				b.Fatalf("AcknowledgeTransferFiles returned false")
+			}
+		}
+	})
 }


### PR DESCRIPTION
A bunch of performance improvements, most impactful first:

1. Made the zero copy path truly zero copy to the socket - get the bytes to the socket asap.
2. Fixed age.Decrypt accidentally doing expensive crypto more than neccesary
3. Fixed lock contention on the ack status maps.

Benchmark transferring 18GiB of state on my 24 core laptop (localhost simulates a very fast network):

With page cache completely empty (the likely production case)
```bash
$ vmtouch -e ~/Hacking/test-data && ./bench.sh /home/jolynch/Hacking/test-data       
           Files: 10010
     Directories: 116
   Evicted Pages: 4926520 (18G)
         Elapsed: 0.28689 seconds
Building pinch...
Starting server in background...
Server is ready at 127.0.0.1:3453
bench: source=/home/jolynch/Hacking/test-data target=/var/lib/pinch/data
Cleaning prior benchmark output...
Preparing manifest...
transfer-probe: strategy=fast server_cpu=24 avg_ms=1 est_link=8400Mbps concurrency=48
transfer loaded: tid=d9bd56ec files=10010 total_size=20175928592 root=/home/jolynch/Hacking/test-data elapsed=107ms manifest=/tmp/pinch/manifest
Running timed start benchmark...
start-plan: strategy=fast link=8400Mbps concurrency=48 (manifest=48) cli-sendbuf=16.00 MiB srv-recvbuf=16.00 MiB
start complete: tid=d9bd56ec requested=10010 downloaded=10010 failed=0 transferred=18.79 GiB speed=2.33 GiB/s elapsed=8.072s

real    0m8.209s
user    0m8.084s
sys     0m35.921s
Flamegraph disabled. Re-run with --flamegraph to generate /tmp/pinch-start.svg and /tmp/pinch-server.svg.

vmtouch -e ~/Hacking/test-data && ./bench.sh /home/jolynch/Hacking/test-data --rsync
           Files: 10010
     Directories: 116
   Evicted Pages: 4926520 (18G)
         Elapsed: 0.062431 seconds
bench (rsync baseline): source=/home/jolynch/Hacking/test-data target=/var/lib/pinch/data
Running: rsync -aW --no-compress --info=progress2 --fsync /home/jolynch/Hacking/test-data/ /var/lib/pinch/data/
 20,175,928,592 100%  763.03MB/s    0:00:25 (xfr#10010, to-chk=0/10126)  

real    0m25.277s
user    0m4.194s
sys     0m10.972s
```

So we beat rsync by 3.12x when the data is not in cache. Now with pagecache:

```bash
$ vmtouch ~/Hacking/test-data && ./bench.sh /home/jolynch/Hacking/test-data
           Files: 10010
     Directories: 116
  Resident Pages: 3096727/4926520  11G/18G  62.9%
         Elapsed: 0.1724 seconds
Building pinch...
Starting server in background...
Server is ready at 127.0.0.1:3453
bench: source=/home/jolynch/Hacking/test-data target=/var/lib/pinch/data
Cleaning prior benchmark output...
Preparing manifest...
transfer-probe: strategy=fast server_cpu=24 avg_ms=1 est_link=8400Mbps concurrency=48
transfer loaded: tid=5ab8a316 files=10010 total_size=20175928592 root=/home/jolynch/Hacking/test-data elapsed=141ms manifest=/tmp/pinch/manifest
Running timed start benchmark...
start-plan: strategy=fast link=8400Mbps concurrency=48 (manifest=48) cli-sendbuf=16.00 MiB srv-recvbuf=16.00 MiB
start complete: tid=5ab8a316 requested=10010 downloaded=10010 failed=0 transferred=18.79 GiB speed=2.87 GiB/s elapsed=6.553s

real    0m6.704s
user    0m7.239s
sys     0m35.139s
Flamegraph disabled. Re-run with --flamegraph to generate /tmp/pinch-start.svg and /tmp/pinch-server.svg.

$ vmtouch ~/Hacking/test-data && ./bench.sh /home/jolynch/Hacking/test-data --rsync 
           Files: 10010
     Directories: 116
  Resident Pages: 4371491/4926520  16G/18G  88.7%
         Elapsed: 0.19123 seconds
bench (rsync baseline): source=/home/jolynch/Hacking/test-data target=/var/lib/pinch/data
Running: rsync -aW --no-compress --info=progress2 --fsync /home/jolynch/Hacking/test-data/ /var/lib/pinch/data/
 20,175,928,592 100%  998.66MB/s    0:00:19 (xfr#10010, to-chk=0/10126)  

real    0m19.320s
user    0m3.796s
sys     0m9.218s
```

And when the data is completely in page cache we beat rsync by 2.8x.

Worth noting that if we can skip fsync on the receiver side we can cut it even further:
```
vmtouch ~/Hacking/test-data && ./bench.sh /home/jolynch/Hacking/test-data --no-sync
           Files: 10010
     Directories: 116
  Resident Pages: 4588994/4926520  17G/18G  93.1%
         Elapsed: 0.19432 seconds
Building pinch...
Starting server in background...
Server is ready at 127.0.0.1:3453
bench: source=/home/jolynch/Hacking/test-data target=/var/lib/pinch/data
Cleaning prior benchmark output...
Preparing manifest...
transfer-probe: strategy=fast server_cpu=24 avg_ms=1 est_link=8400Mbps concurrency=48
transfer loaded: tid=836fdb5a files=10010 total_size=20175928592 root=/home/jolynch/Hacking/test-data elapsed=131ms manifest=/tmp/pinch/manifest
Running timed start benchmark...
start-plan: strategy=fast link=8400Mbps concurrency=48 (manifest=48) cli-sendbuf=16.00 MiB srv-recvbuf=16.00 MiB
start complete: tid=836fdb5a requested=10010 downloaded=10010 failed=0 transferred=18.79 GiB speed=3.88 GiB/s elapsed=4.845s

real    0m4.967s
user    0m7.431s
sys     0m33.292s
Flamegraph disabled. Re-run with --flamegraph to generate /tmp/pinch-start.svg and /tmp/pinch-server.svg.
```

That last run is about as fast as my 1 TiB WD Black SN850X NVMe SSD can read data ... so we've hit the speed limit of my laptop.