### PR TITLE
Add progress file reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Based off of https://github.com/facebook/zstd/issues/880
 
 # Step 1. Image used to build the binary
-FROM alpine:3.21 as builder
+FROM alpine:3.21 AS builder
 
 RUN apk --no-cache add make gcc libc-dev git
 
@@ -60,7 +60,7 @@ COPY --from=builder /zstd_src/LICENSE /usr/local/share/licenses/zstd/
 COPY --from=builder /xxh_src/LICENSE /usr/local/share/licenses/xxhash/
 COPY --from=builder /age/LICENSE /usr/local/share/licenses/age/
 
-ENV PAGER less
+ENV PAGER=less
 
 # Zstd is probably the right default choice
 CMD ["/usr/local/bin/zstd"]

--- a/pinch-server
+++ b/pinch-server
@@ -26,9 +26,9 @@ mkdir -p "/var/lib/pinch/keys"
 mkdir -p "/var/lib/pinch/out"
 
 if [[ "${DETACH}" == "true" ]]; then
-    DOCKER_RUN="docker run --rm -d -v /var/lib/pinch/:/var/lib/pinch -p 127.0.0.1:${PORT}:8080 --name pinch-server jolynch/pinch-server pinch-server -listen 0.0.0.0:8080 -die-after ${DIEAFTER}"
+    DOCKER_RUN="docker run --rm -d -v /var/lib/pinch/:/var/lib/pinch -p 127.0.0.1:${PORT}:8080 --name pinch-server jolynch/pinch-server pinch-server pipesrv -listen 0.0.0.0:8080 -die-after ${DIEAFTER}"
 else
-    DOCKER_RUN="docker run --rm -v /var/lib/pinch/:/var/lib/pinch -p 127.0.0.1:${PORT}:8080 --name pinch-server jolynch/pinch-server pinch-server -listen 0.0.0.0:8080 -die-after ${DIEAFTER}"
+    DOCKER_RUN="docker run --rm -v /var/lib/pinch/:/var/lib/pinch -p 127.0.0.1:${PORT}:8080 --name pinch-server jolynch/pinch-server pinch-server pipesrv -listen 0.0.0.0:8080 -die-after ${DIEAFTER}"
 fi
 
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 ARG REGISTRY=docker.io
 
 ###### BUILD CONTAINER ######
-FROM $REGISTRY/golang:latest as builder
+FROM $REGISTRY/golang:latest AS builder
 
 # Dependencies e.g.
 # RUN go get -u google.golang.org/grpc
@@ -35,4 +35,4 @@ COPY --from=builder /usr/local/bin/dumb-init /usr/bin/dumb-init
 COPY --from=builder /go/src/pinch-server /usr/local/bin/pinch-server
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/usr/local/bin/pinch-server"]
+CMD ["/usr/local/bin/pinch-server", "pipesrv"]

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -237,8 +237,8 @@ type DownloadFileResponse struct {
 }
 
 type DownloadBatchRequest struct {
-	Manifest *Manifest
-	FileIDs  []uint64
+	Manifest     *Manifest
+	FileIDs      []uint64
 	OutputWriter func(ManifestEntry, int64) (io.WriteCloser, func() error, error)
 	// BatchMaxBytes is the unit of parallel work for a single large file: when a file
 	// exceeds BatchMaxBytes, it is split into windows of this size and downloaded
@@ -1096,8 +1096,8 @@ func (c *Client) downloadManifestBatchSequential(
 	} else {
 		planGroups, targetGroups := splitSequentialGroups(plans, targets, k)
 		type groupResult struct {
-			files     []DownloadFileResponse
-			acks      []AcknowledgeFileProgressRequest
+			files      []DownloadFileResponse
+			acks       []AcknowledgeFileProgressRequest
 			progresses []seqAckProgress
 		}
 		results := make([]groupResult, len(planGroups))
@@ -1869,7 +1869,6 @@ func retryAck(ctx context.Context, fn func(context.Context) error) error {
 	return lastErr
 }
 
-
 func copyCompCounts(src map[string]uint64) map[string]uint64 {
 	if len(src) == 0 {
 		return nil
@@ -2202,7 +2201,6 @@ func marshalManifest(manifest *Manifest) ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
-
 func resolveManifestEntryPath(manifest *Manifest, fileID uint64) (ManifestEntry, string, error) {
 	entry, ok := manifest.EntryByID(fileID)
 	if !ok {
@@ -2222,7 +2220,6 @@ func cloneTrailerMetadata(meta *FileTrailerMetadata) *FileTrailerMetadata {
 	cloned := *meta
 	return &cloned
 }
-
 
 type fileStream struct {
 	respBody io.Closer
@@ -2369,11 +2366,11 @@ func (c *Client) newFileStream(respBody io.ReadCloser, ageIdentity string, fileS
 	bufferHint := c.fileStreamBufferHint(fileSizeHint, firstMeta.Size)
 	readBuf, release := c.acquireFrameReadBuffer(bufferHint)
 	stream := &fileStream{
-		respBody: respBody,
-		br:       newPooledLineReader(probe, readBuf),
-		identity: identity,
-		meta:     &FileFrameMeta{},
-		pending:  &firstMeta,
+		respBody:  respBody,
+		br:        newPooledLineReader(probe, readBuf),
+		identity:  identity,
+		meta:      &FileFrameMeta{},
+		pending:   &firstMeta,
 		releaseBr: release,
 	}
 	if err := stream.openNextFrame(); err != nil {

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -22,20 +22,20 @@ import (
 const maxTCPLineBytes = 4 * 1024 * 1024
 
 type tcpAuthState struct {
-	publicKey      string
-	identity       string
-	parsedIdentity age.Identity
-	hasAuth        bool
+	publicKey       string
+	identity        string
+	parsedIdentity  age.Identity
+	hasAuth         bool
 	encryptCommands bool
 }
 
 type probeResponse struct {
-	ServerCPU      int
-	CTS0           int64
-	CTS1           int64
-	STS0           int64
-	STS1           int64
-	ProbeBytes     int64
+	ServerCPU       int
+	CTS0            int64
+	CTS1            int64
+	STS0            int64
+	STS1            int64
+	ProbeBytes      int64
 	ServerWmemBytes int64
 }
 

--- a/server/internal/cmd/filexfercli/cli.go
+++ b/server/internal/cmd/filexfercli/cli.go
@@ -20,8 +20,11 @@ import (
 
 	"runtime/trace"
 
+	"sync/atomic"
+
 	"filippo.io/age"
 	. "github.com/jolynch/pinch/filexfer"
+	"github.com/jolynch/pinch/internal/filexfer"
 	"github.com/jolynch/pinch/internal/filexfer/encoding"
 	"github.com/jolynch/pinch/utils"
 )
@@ -60,6 +63,26 @@ func (sw *synchronizedWriter) Write(p []byte) (int, error) {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	return sw.w.Write(p)
+}
+
+type countingWriter struct {
+	io.Writer
+	total *atomic.Int64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.Writer.Write(p)
+	if n > 0 {
+		cw.total.Add(int64(n))
+	}
+	return n, err
+}
+
+func (cw *countingWriter) Close() error {
+	if c, ok := cw.Writer.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 const defaultFileListener = "127.0.0.1:3453"
@@ -414,6 +437,8 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	var noSync bool
 	var verbose bool
 	var traceFile string
+	var progressFilePath string
+	var progressIntervalRaw string
 	cf.StringVar(&txferID, "", "tid", "", "transfer id")
 	cf.StringVar(&manifestPath, "", "manifest", "", "path to manifest file (default: <tid>.fm2)")
 	cf.StringVar(&fileIDRaw, "", "fd", "", "file id to download")
@@ -428,6 +453,8 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	cf.StringVar(&batchSizeRaw, "b", "batch-size", ackEveryRaw, "parallel batch size, unit of work per concurrent request")
 	cf.BoolVar(&noSync, "", "no-sync", false, "ack without disk sync")
 	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	cf.StringVar(&progressFilePath, "", "progress-path", "", "write integer % to this file/pipe")
+	cf.StringVar(&progressIntervalRaw, "", "progress-path-interval", "1s", "progress write interval (e.g. 500ms, 10s)")
 	if err := cf.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -438,6 +465,11 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	defer stopTracing()
 	if fileIDRaw == "" {
 		fmt.Fprintln(stderr, "get requires --fd")
+		return 2
+	}
+	progressInterval, err := time.ParseDuration(progressIntervalRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid --progress-path-interval: %v\n", err)
 		return 2
 	}
 	ackEvery, err := encoding.ParseByteSize(ackEveryRaw)
@@ -532,14 +564,34 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 		return 0
 	}
 	outputPath := resolveDownloadDestinationPath(entry, outRoot, outFile)
+	var totalCopied atomic.Int64
+	outputWriter := func(me ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
+		destPath := resolveDownloadDestinationPath(me, outRoot, outFile)
+		w, syncFn, err := openDownloadOutput(me, offset, destPath, stdout, noSync)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &countingWriter{Writer: w, total: &totalCopied}, syncFn, nil
+	}
+	if progressFilePath != "" {
+		totalBytes := entry.Size
+		stopProgressFile := filexfer.StartProgressFileWriter(context.Background(), progressFilePath, progressInterval, func() int {
+			if totalBytes <= 0 {
+				return 100
+			}
+			pct := int(totalCopied.Load() * 100 / totalBytes)
+			if pct > 100 {
+				pct = 100
+			}
+			return pct
+		})
+		defer func() { stopProgressFile(err == nil) }()
+	}
 	downloadBatchResp, err := client.DownloadFilesFromManifestBatch(context.Background(), DownloadBatchRequest{
-		Manifest:      manifest,
-		FileIDs:       []uint64{fileID},
-		BatchMaxBytes: batchSize,
-		OutputWriter: func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
-			destPath := resolveDownloadDestinationPath(entry, outRoot, outFile)
-			return openDownloadOutput(entry, offset, destPath, stdout, noSync)
-		},
+		Manifest:        manifest,
+		FileIDs:         []uint64{fileID},
+		BatchMaxBytes:   batchSize,
+		OutputWriter:    outputWriter,
 		AgePublicKey:    agePublicKey,
 		AgeIdentity:     ageIdentity,
 		ProgressUpdates: progressUpdates,
@@ -589,6 +641,8 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 	var deleteRemoved bool
 	var probeBytesRaw string
 	var traceFile string
+	var progressFilePath string
+	var progressIntervalRaw string
 	cf.StringVar(&sourceDir, "s", "source-directory", "", "absolute source directory on server")
 	cf.StringVar(&manifestPath, "", "manifest", "", "path to existing manifest file (required)")
 	cf.StringVar(&manifestOut, "o", "", "", "output path for updated manifest (default: overwrite --manifest)")
@@ -606,6 +660,8 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 	probeBytesRaw = encoding.HumanBytes(defaultCLIProbeBytes)
 	cf.StringVar(&probeBytesRaw, "", "probe-bytes", probeBytesRaw, "probe payload size")
 	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	cf.StringVar(&progressFilePath, "", "progress-path", "", "write integer % to this file/pipe")
+	cf.StringVar(&progressIntervalRaw, "", "progress-path-interval", "1s", "progress write interval (e.g. 500ms, 10s)")
 	if err := cf.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -624,6 +680,11 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 	}
 	if manifestOut == "" {
 		manifestOut = manifestPath
+	}
+	progressInterval, err := time.ParseDuration(progressIntervalRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid --progress-path-interval: %v\n", err)
+		return 2
 	}
 	ackEvery, err := encoding.ParseByteSize(ackEveryRaw)
 	if err != nil || ackEvery <= 0 {
@@ -853,11 +914,39 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 	}
 	defer stopProgress()
 
+	var totalCopied atomic.Int64
+	outputWriter := func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
+		destPath := resolveDownloadDestinationPath(entry, outRoot, "")
+		w, syncFn, err := openDownloadOutput(entry, offset, destPath, nil, noSync)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &countingWriter{Writer: w, total: &totalCopied}, syncFn, nil
+	}
+
 	startAll := time.Now()
 	var completed int64
 	var totalTransferred int64
 	var failures []error
 	var failuresMu sync.Mutex
+
+	if progressFilePath != "" {
+		var totalBytes int64
+		for _, e := range pendingEntries {
+			totalBytes += e.Size
+		}
+		stopProgressFile := filexfer.StartProgressFileWriter(context.Background(), progressFilePath, progressInterval, func() int {
+			if totalBytes <= 0 {
+				return 100
+			}
+			pct := int(totalCopied.Load() * 100 / totalBytes)
+			if pct > 100 {
+				pct = 100
+			}
+			return pct
+		})
+		defer func() { stopProgressFile(len(failures) == 0) }()
+	}
 	recordFailure := func(err error) {
 		if err == nil {
 			return
@@ -868,12 +957,9 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 	}
 
 	startResp, err := client.StartFromManifest(context.Background(), StartFromManifestRequest{
-		Manifest: mergedManifest,
-		Entries:  pendingEntries,
-		OutputWriter: func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
-			destPath := resolveDownloadDestinationPath(entry, outRoot, "")
-			return openDownloadOutput(entry, offset, destPath, nil, noSync)
-		},
+		Manifest:        mergedManifest,
+		Entries:         pendingEntries,
+		OutputWriter:    outputWriter,
 		AgePublicKey:    agePublicKey,
 		AgeIdentity:     ageIdentity,
 		Concurrency:     effectiveConcurrency,
@@ -955,6 +1041,8 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 	var progress bool
 	var perFile bool
 	var deadlineRaw string
+	var progressFilePath string
+	var progressIntervalRaw string
 	cf.StringVar(&txferID, "", "tid", "", "transfer id")
 	cf.StringVar(&manifestPath, "", "manifest", "", "path to manifest file (default: <tid>.fm2)")
 	cf.StringVar(&outRoot, "", "out-root", ".", "output root")
@@ -971,6 +1059,8 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 	cf.StringVar(&deadlineRaw, "", "deadline", "", "transfer deadline (e.g. 60s, 5m)")
 	var traceFile string
 	cf.StringVar(&traceFile, "", "trace", "", "write runtime/trace output to this file")
+	cf.StringVar(&progressFilePath, "", "progress-path", "", "write integer % to this file/pipe")
+	cf.StringVar(&progressIntervalRaw, "", "progress-path-interval", "1s", "progress write interval (e.g. 500ms, 10s)")
 	if err := cf.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -979,6 +1069,11 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 	}
 	stopTracing := startTracing(traceFile, stderr)
 	defer stopTracing()
+	progressInterval, err := time.ParseDuration(progressIntervalRaw)
+	if err != nil {
+		fmt.Fprintf(stderr, "invalid --progress-path-interval: %v\n", err)
+		return 2
+	}
 	// Compute verbosity level: 0=quiet, 1=progress, 2=per-file.
 	verbosity := 0
 	if progress || verbose {
@@ -1139,13 +1234,36 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 		}
 		pendingEntries = append(pendingEntries, entry)
 	}
+	var totalCopied atomic.Int64
+	outputWriter := func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
+		destPath := resolveDownloadDestinationPath(entry, outRoot, "")
+		w, syncFn, err := openDownloadOutput(entry, offset, destPath, nil, noSync)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &countingWriter{Writer: w, total: &totalCopied}, syncFn, nil
+	}
+	if progressFilePath != "" {
+		var totalBytes int64
+		for _, e := range pendingEntries {
+			totalBytes += e.Size
+		}
+		stopProgressFile := filexfer.StartProgressFileWriter(context.Background(), progressFilePath, progressInterval, func() int {
+			if totalBytes <= 0 {
+				return 100
+			}
+			pct := int(totalCopied.Load() * 100 / totalBytes)
+			if pct > 100 {
+				pct = 100
+			}
+			return pct
+		})
+		defer func() { stopProgressFile(len(failures) == 0) }()
+	}
 	startResp, err := client.StartFromManifest(context.Background(), StartFromManifestRequest{
-		Manifest: manifest,
-		Entries:  pendingEntries,
-		OutputWriter: func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
-			destPath := resolveDownloadDestinationPath(entry, outRoot, "")
-			return openDownloadOutput(entry, offset, destPath, nil, noSync)
-		},
+		Manifest:        manifest,
+		Entries:         pendingEntries,
+		OutputWriter:    outputWriter,
 		AgePublicKey:    agePublicKey,
 		AgeIdentity:     ageIdentity,
 		Concurrency:     effectiveConcurrency,
@@ -1275,7 +1393,7 @@ func startVerboseStatusPolling(txferID string, client *Client, stderr io.Writer)
 				if rateBps > 0 && s.TotalSize > s.DoneSize {
 					remaining := float64(s.TotalSize - s.DoneSize)
 					etaSec := remaining / rateBps
-					etaPart = fmt.Sprintf(" eta=%s", (time.Duration(etaSec*float64(time.Second))).Round(time.Second))
+					etaPart = fmt.Sprintf(" eta=%s", (time.Duration(etaSec * float64(time.Second))).Round(time.Second))
 				}
 				fmt.Fprintf(
 					stderr,

--- a/server/internal/cmd/filexfercli/flags.go
+++ b/server/internal/cmd/filexfercli/flags.go
@@ -27,12 +27,12 @@ func newCLIFlags(name string) *cliFlags {
 	return &cliFlags{fs: flag.NewFlagSet(name, flag.ContinueOnError)}
 }
 
-func (c *cliFlags) SetOutput(w io.Writer)                       { c.fs.SetOutput(w) }
-func (c *cliFlags) Parse(args []string) error                   { return c.fs.Parse(args) }
-func (c *cliFlags) Arg(i int) string                            { return c.fs.Arg(i) }
-func (c *cliFlags) Args() []string                              { return c.fs.Args() }
-func (c *cliFlags) NArg() int                                   { return c.fs.NArg() }
-func (c *cliFlags) Visit(fn func(*flag.Flag))                   { c.fs.Visit(fn) }
+func (c *cliFlags) SetOutput(w io.Writer)     { c.fs.SetOutput(w) }
+func (c *cliFlags) Parse(args []string) error { return c.fs.Parse(args) }
+func (c *cliFlags) Arg(i int) string          { return c.fs.Arg(i) }
+func (c *cliFlags) Args() []string            { return c.fs.Args() }
+func (c *cliFlags) NArg() int                 { return c.fs.NArg() }
+func (c *cliFlags) Visit(fn func(*flag.Flag)) { c.fs.Visit(fn) }
 
 // StringVar registers a string flag. Pass short="" for long-only, long="" for short-only.
 func (c *cliFlags) StringVar(p *string, short, long, defVal, usage string) {

--- a/server/internal/filexfer/ftcp/send.go
+++ b/server/internal/filexfer/ftcp/send.go
@@ -949,7 +949,6 @@ func streamBufferedRead(
 	return prepareLatency, nil
 }
 
-
 func acquireCompressedFrameBuffer(logicalSize int64, comp string) *bytes.Buffer {
 	maxEncoded, err := encoding.MaxEncodedFrameSizeBytes(comp, logicalSize)
 	if err != nil || maxEncoded <= 0 {
@@ -1012,16 +1011,16 @@ func logicalBufferPool(size int) *sync.Pool {
 
 func logicalBufferBucketSize(maxChunk int64) int {
 	const (
-		KiB   = 1024
-		MiB   = 1024 * KiB
-		bucket4KiB = 4 * KiB
-		bucket16KiB = 16 * KiB
-		bucket64KiB = 64 * KiB
+		KiB          = 1024
+		MiB          = 1024 * KiB
+		bucket4KiB   = 4 * KiB
+		bucket16KiB  = 16 * KiB
+		bucket64KiB  = 64 * KiB
 		bucket256KiB = 256 * KiB
-		bucket1MiB = 1 * MiB
-		bucket2MiB = 2 * MiB
-		bucket4MiB = 4 * MiB
-		bucket8MiB = 8 * MiB
+		bucket1MiB   = 1 * MiB
+		bucket2MiB   = 2 * MiB
+		bucket4MiB   = 4 * MiB
+		bucket8MiB   = 8 * MiB
 	)
 	if maxChunk <= int64(bucket4KiB) {
 		return bucket4KiB

--- a/server/internal/filexfer/ftcp/send_test.go
+++ b/server/internal/filexfer/ftcp/send_test.go
@@ -93,10 +93,10 @@ func (d *sendTestDeps) VerifyTransferFileWindowHash(string, uint64, int64, strin
 
 func (d *sendTestDeps) AcknowledgeTransferFile(string, uint64, int64) bool { return false }
 
-func (d *sendTestDeps) SetTransferDeadline(string, int64) bool        { return false }
+func (d *sendTestDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (d *sendTestDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
-func (d *sendTestDeps) MarkTransferTooSlow(string) bool               { return false }
-func (d *sendTestDeps) Root() string                                  { return "/" }
+func (d *sendTestDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (d *sendTestDeps) Root() string                                     { return "/" }
 
 func TestParseSENDRequestCompDefaultsAndModes(t *testing.T) {
 	req, err := ParseRequest([]byte(`SEND tx1 fd=1 "/tmp/a.txt"`))

--- a/server/internal/filexfer/ftcp/server.go
+++ b/server/internal/filexfer/ftcp/server.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net"
 	"runtime/trace"
+	"sync/atomic"
 	"time"
 
 	"filippo.io/age"
+	"github.com/jolynch/pinch/internal/filexfer"
 	"github.com/jolynch/pinch/internal/filexfer/limit"
 )
 
@@ -25,6 +27,8 @@ type ServerOptions struct {
 	SocketWriteBufferBytes int
 	SyncTimeout            time.Duration // 0 = no timeout; bounds SYNC response write time
 	RootDir                string        // "/" or "" means unrestricted
+	ProgressPath           string        // write transfer % to this file/pipe
+	ProgressInterval       time.Duration // tick interval for progress writes (default 1s)
 }
 
 type HandlerFunc func(context.Context, Request, io.Writer, Deps) error
@@ -48,6 +52,34 @@ func Serve(listener net.Listener, opts ServerOptions) error {
 	if deps == nil {
 		deps = NewRuntimeDepsWithRoot(opts.RootDir)
 	}
+
+	var onTransferCreated func(string)
+	if opts.ProgressPath != "" {
+		interval := opts.ProgressInterval
+		if interval <= 0 {
+			interval = time.Second
+		}
+		var activeTransferID atomic.Value
+		onTransferCreated = func(id string) { activeTransferID.Store(id) }
+		stopProgress := filexfer.StartProgressFileWriter(
+			context.Background(), opts.ProgressPath, interval, func() int {
+				id, _ := activeTransferID.Load().(string)
+				if id == "" {
+					return 0
+				}
+				t, ok := deps.GetTransfer(id)
+				if !ok || t.TotalSize <= 0 {
+					return 0
+				}
+				pct := int(t.DoneSize * 100 / t.TotalSize)
+				if pct > 100 {
+					pct = 100
+				}
+				return pct
+			})
+		defer stopProgress(true)
+	}
+
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -57,7 +89,7 @@ func Serve(listener net.Listener, opts ServerOptions) error {
 			}
 			return err
 		}
-		go handleConn(conn, opts, deps)
+		go handleConn(conn, opts, deps, onTransferCreated)
 	}
 }
 
@@ -72,9 +104,10 @@ type connSession struct {
 	respOut                io.Writer
 	closeResp              func() error
 	wroteBytes             bool
+	onTransferCreated      func(string)
 }
 
-func handleConn(conn net.Conn, opts ServerOptions, deps Deps) {
+func handleConn(conn net.Conn, opts ServerOptions, deps Deps, onTransferCreated func(string)) {
 	defer conn.Close()
 	s := &connSession{
 		conn:                   conn,
@@ -86,6 +119,7 @@ func handleConn(conn net.Conn, opts ServerOptions, deps Deps) {
 		syncTimeout:            opts.SyncTimeout,
 		respOut:                conn,
 		closeResp:              func() error { return nil },
+		onTransferCreated:      onTransferCreated,
 	}
 	if tc, ok := conn.(*net.TCPConn); ok {
 		_ = tc.SetNoDelay(true)
@@ -179,7 +213,10 @@ func (s *connSession) handleCommand(ctx context.Context, req Request, in io.Read
 		if s.syncTimeout > 0 {
 			_ = s.conn.SetWriteDeadline(time.Now().Add(s.syncTimeout))
 		}
-		return handleSYNCWithInput(ctx, req, in, out, s.deps)
+		return handleSYNCWithInput(ctx, req, in, out, s.deps, s.onTransferCreated)
+	}
+	if req.Verb == VerbTXFER {
+		return handleTXFERWithCallback(ctx, req, out, s.deps, s.onTransferCreated)
 	}
 	handler, ok := handlers[req.Verb]
 	if !ok || req.Verb == VerbUnknown {

--- a/server/internal/filexfer/ftcp/status_test.go
+++ b/server/internal/filexfer/ftcp/status_test.go
@@ -41,10 +41,10 @@ func (f fakeDeps) VerifyTransferFileWindowHash(string, uint64, int64, string) bo
 }
 func (f fakeDeps) AcknowledgeTransferFile(string, uint64, int64) bool { return true }
 
-func (f fakeDeps) SetTransferDeadline(string, int64) bool        { return false }
+func (f fakeDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (f fakeDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
-func (f fakeDeps) MarkTransferTooSlow(string) bool               { return false }
-func (f fakeDeps) Root() string                                  { return "/" }
+func (f fakeDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (f fakeDeps) Root() string                                     { return "/" }
 
 func TestHandleSTATUSWritesStatusLine(t *testing.T) {
 	req := Request{Verb: VerbSTATUS, Params: []map[string]string{{"txferid": "tx1"}}}

--- a/server/internal/filexfer/ftcp/sync.go
+++ b/server/internal/filexfer/ftcp/sync.go
@@ -84,7 +84,7 @@ func handleSYNCCommand(_ context.Context, _ Request, _ io.Writer, _ Deps) error 
 	return protocolErr{code: "INTERNAL", message: "SYNC requires input reader, use handleSYNCWithInput"}
 }
 
-func handleSYNCWithInput(ctx context.Context, req Request, in io.Reader, out io.Writer, deps Deps) error {
+func handleSYNCWithInput(ctx context.Context, req Request, in io.Reader, out io.Writer, deps Deps, onTransferCreated func(string)) error {
 	parsed, err := parseSYNCRequest(req)
 	if err != nil {
 		return err
@@ -106,6 +106,9 @@ func handleSYNCWithInput(ctx context.Context, req Request, in io.Reader, out io.
 	transfer, err := deps.NewTransfer(root, 0, 0)
 	if err != nil {
 		return protocolErr{code: "INTERNAL", message: "failed to initialize transfer"}
+	}
+	if onTransferCreated != nil {
+		onTransferCreated(transfer.ID)
 	}
 	if ok := deps.SetTransferHints(transfer.ID, parsed.Mode, parsed.LinkMbps, parsed.Concurrency); !ok {
 		return protocolErr{code: "INTERNAL", message: "failed to persist transfer hints"}

--- a/server/internal/filexfer/ftcp/sync_test.go
+++ b/server/internal/filexfer/ftcp/sync_test.go
@@ -149,7 +149,6 @@ func TestHandleSYNCMixedDelta(t *testing.T) {
 	}
 }
 
-
 // --- Test helpers ---
 
 func writeTestFile(t *testing.T, root, rel, content string) {
@@ -204,7 +203,7 @@ func runSYNCTest(t *testing.T, root string, oldManifest string) ([]encoding.Mani
 
 	deps := &syncTestDeps{}
 	var out bytes.Buffer
-	if err := handleSYNCWithInput(context.Background(), req, &input, &out, deps); err != nil {
+	if err := handleSYNCWithInput(context.Background(), req, &input, &out, deps, nil); err != nil {
 		t.Fatalf("handleSYNCWithInput: %v", err)
 	}
 

--- a/server/internal/filexfer/ftcp/txfer.go
+++ b/server/internal/filexfer/ftcp/txfer.go
@@ -90,7 +90,7 @@ func parseTXFERRequest(req Request) (txferRequest, error) {
 	}, nil
 }
 
-func handleTXFER(_ context.Context, req Request, out io.Writer, deps Deps) error {
+func handleTXFERWithCallback(ctx context.Context, req Request, out io.Writer, deps Deps, onCreated func(string)) error {
 	parsed, err := parseTXFERRequest(req)
 	if err != nil {
 		return err
@@ -104,6 +104,9 @@ func handleTXFER(_ context.Context, req Request, out io.Writer, deps Deps) error
 	transfer, err := deps.NewTransfer(root, 0, 0)
 	if err != nil {
 		return protocolErr{code: "INTERNAL", message: "failed to initialize transfer"}
+	}
+	if onCreated != nil {
+		onCreated(transfer.ID)
 	}
 	if ok := deps.SetTransferHints(transfer.ID, parsed.Mode, parsed.LinkMbps, parsed.Concurrency); !ok {
 		return protocolErr{code: "INTERNAL", message: "failed to persist transfer hints"}
@@ -140,6 +143,10 @@ func handleTXFER(_ context.Context, req Request, out io.Writer, deps Deps) error
 	}
 	cleanupTransfer = false
 	return nil
+}
+
+func handleTXFER(ctx context.Context, req Request, out io.Writer, deps Deps) error {
+	return handleTXFERWithCallback(ctx, req, out, deps, nil)
 }
 
 func validateDirectory(directory string) error {
@@ -293,4 +300,3 @@ func isBrokenPipe(err error) bool {
 		errors.Is(err, syscall.EPIPE) ||
 		errors.Is(err, syscall.ECONNRESET)
 }
-

--- a/server/internal/filexfer/ftcp/txfer_test.go
+++ b/server/internal/filexfer/ftcp/txfer_test.go
@@ -61,10 +61,10 @@ func (d *txferTestDeps) VerifyTransferFileWindowHash(string, uint64, int64, stri
 
 func (d *txferTestDeps) AcknowledgeTransferFile(string, uint64, int64) bool { return true }
 
-func (d *txferTestDeps) SetTransferDeadline(string, int64) bool        { return false }
+func (d *txferTestDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (d *txferTestDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
-func (d *txferTestDeps) MarkTransferTooSlow(string) bool               { return false }
-func (d *txferTestDeps) Root() string                                  { return "/" }
+func (d *txferTestDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (d *txferTestDeps) Root() string                                     { return "/" }
 
 func TestParseTXFERRequestRequiresHints(t *testing.T) {
 	req, err := ParseRequest([]byte(`TXFER "/tmp" mode=fast link-mbps=900 concurrency=12`))

--- a/server/internal/filexfer/progress.go
+++ b/server/internal/filexfer/progress.go
@@ -1,0 +1,68 @@
+package filexfer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// StartProgressFileWriter starts a background goroutine that periodically
+// writes an integer percentage (0–100) to a file or named pipe at path.
+// The file is opened non-blocking so FIFOs without a reader don't hang.
+// If the file/pipe doesn't exist or can't be opened, it silently retries
+// on the next tick.
+//
+// The returned stop function must be called when the operation completes.
+// If success is true the final write is "100\n"; otherwise the last-known
+// percentage is written so external tools can distinguish success from failure.
+func StartProgressFileWriter(ctx context.Context, path string, interval time.Duration, pctFn func() int) (stop func(success bool)) {
+	ctx, cancel := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var lastPct int
+
+	writeOnce := func(pct int) {
+		fd, err := unix.Open(path, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_NONBLOCK, 0644)
+		if err != nil {
+			return
+		}
+		f := os.NewFile(uintptr(fd), path)
+		fmt.Fprintf(f, "%d\n", pct)
+		f.Close()
+	}
+
+	lastWritten := -1
+
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastPct = pctFn()
+				if lastPct != lastWritten {
+					writeOnce(lastPct)
+					lastWritten = lastPct
+				}
+			}
+		}
+	}()
+
+	return func(success bool) {
+		cancel()
+		wg.Wait()
+		if success {
+			writeOnce(100)
+		} else {
+			writeOnce(lastPct)
+		}
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -826,6 +826,8 @@ Options:
   -k, --keys string           age keys directory (default "/var/lib/pinch/keys")
       --require-auth          require AUTH before commands
       --trace string          write runtime/trace to this file
+      --progress-path string           write transfer % to this file/pipe
+      --progress-path-interval string  progress write interval (default "1s")
 `)
 	}
 	fs.StringVar(&fileListener, "listen", fileListener, "")
@@ -840,11 +842,20 @@ Options:
 	fs.StringVar(&keysDir, "k", keysDir, "")
 	requireAuth := fs.Bool("require-auth", false, "")
 	traceFile := fs.String("trace", "", "")
+	var progressFilePath string
+	var progressIntervalRaw string
+	fs.StringVar(&progressFilePath, "progress-path", "", "")
+	fs.StringVar(&progressIntervalRaw, "progress-path-interval", "1s", "")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
 		}
 		return 2
+	}
+
+	progressInterval, err := time.ParseDuration(progressIntervalRaw)
+	if err != nil {
+		log.Fatalf("Invalid --progress-path-interval: %v", err)
 	}
 
 	if *traceFile != "" {
@@ -862,7 +873,6 @@ Options:
 	if !makeDirs(keysDir) {
 		log.Fatalf("Could not setup key directory, dying")
 	}
-	var err error
 	serverKey, err = loadServerAgeIdentity(keysDir)
 	if err != nil {
 		log.Fatalf("AGE key setup failed: %v", err)
@@ -893,6 +903,8 @@ Options:
 		Limiter:                fileStreamLimiter,
 		SocketWriteBufferBytes: socketWriteBufBytes,
 		RootDir:                chroot,
+		ProgressPath:           progressFilePath,
+		ProgressInterval:       progressInterval,
 	}); serveErr != nil {
 		log.Fatalf("File transfer listener stopped: %v", serveErr)
 	}

--- a/tests/test_server.sh
+++ b/tests/test_server.sh
@@ -17,6 +17,14 @@ DATA="${DATA:-tests/state/webster.txt}"
 ./pinch-server
 URL="localhost:${PORT}"
 
+# Wait for server to be ready
+for i in $(seq 1 30); do
+    if (echo >/dev/tcp/localhost/${PORT}) 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
 FD=$(curl -s "${URL}/pinch?min-level=1&timeout=10s" | jq '.handles | keys[0]' -r)
 RFD=$(curl -s "${URL}/unpinch?timeout=10s" | jq '.handles | keys[0]' -r)
 


### PR DESCRIPTION
This should make us compatible with progress reporting tools that can read the output of pipe files but can't make tcp calls for status.