### PR TITLE
Refactor and harden our Encryption implementation

### DIFF
--- a/server/bench.sh
+++ b/server/bench.sh
@@ -22,7 +22,7 @@ Options:
   --skip-fsync               Skip fdatasync after each file/window (passed to copy).
   --no-sync                  Alias for --skip-fsync.
   --concurrency N            Copy command concurrency (default: 128).
-  --encrypt MODE             Encryption mode passed to CLI (supported: age|aes).
+  --encrypt MODE             Client encryption mode (supported: age|aes).
   --compress MODE            Compression mode passed to copy (adapt|none|lz4|zstd).
   --disable-zero-copy        Force server to use buffered send path (no tee/splice).
   --freq HZ                  perf sample frequency (default: 199).
@@ -306,9 +306,6 @@ start_server() {
   mkdir -p "${SERVER_IN}" "${SERVER_OUT}" "${SERVER_KEYS}"
   echo "Starting server in background..."
   local server_args=(filesrv -l "${SERVER_URL}" -k "${SERVER_KEYS}")
-  if [[ -n "${ENCRYPT_MODE}" ]]; then
-    server_args+=(--encrypt "${ENCRYPT_MODE}")
-  fi
   if [[ "${TRACE}" == "true" ]]; then
     server_args+=(--trace "${SERVER_TRACE}")
   fi

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -72,12 +72,6 @@ func WithContextDialer(dialer func(context.Context, string) (net.Conn, error)) C
 	})
 }
 
-func WithServerAgePublicKey(publicKey string) ClientOption {
-	return clientOptionFunc(func(c *Client) {
-		c.ServerAgePublicKey = strings.TrimSpace(publicKey)
-	})
-}
-
 func WithFileRequestWindowBytes(windowBytes int64) ClientOption {
 	return clientOptionFunc(func(c *Client) {
 		c.FileRequestWindowBytes = windowBytes
@@ -161,7 +155,6 @@ func normalizeComp(comp string) string {
 
 type Client struct {
 	FileAddr                string
-	ServerAgePublicKey      string
 	FileRequestWindowBytes  int64
 	BatchMaxBytes           int64
 	FrameBufferBytes        int
@@ -441,7 +434,6 @@ func NewClient(fileAddr string, opts ...ClientOption) *Client {
 	trimmed := strings.TrimSpace(fileAddr)
 	c := &Client{
 		FileAddr:                trimmed,
-		ServerAgePublicKey:      strings.TrimSpace(os.Getenv("PINCH_FILE_SERVER_AGE_PUBLIC_KEY")),
 		FileRequestWindowBytes:  defaultClientRequestWindowBytes,
 		FrameBufferBytes:        defaultClientFrameBufferBytes,
 		MaxFrameReadBufferBytes: defaultClientMaxFrameReadBufferBytes,
@@ -2856,7 +2848,7 @@ func decodePayloadReader(payload io.Reader, comp string, enc string, identity ag
 		if identity == nil {
 			return nil, errors.New("missing identity for AES encrypted frame")
 		}
-		decrypted, err := intencoding.AESGCMDecrypt(payload, identity, 0)
+		decrypted, err := intencoding.AESGCMDecrypt(payload, identity)
 		if err != nil {
 			return nil, err
 		}

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -23,12 +23,12 @@ import (
 const maxTCPLineBytes = 4 * 1024 * 1024
 
 type tcpAuthState struct {
-	publicKey       string
-	identity        string
-	parsedIdentity  age.Identity
-	hasAuth         bool
-	encryptCommands bool
-	encMode         string // "age" (default) or "aes"
+	publicKey      string // client's age public key
+	identity       string // client's age identity (private key)
+	parsedIdentity age.Identity
+	serverKey      string // server's age public key (discovered via AUTH key)
+	hasAuth        bool
+	encMode        string // "age" or "aes"
 }
 
 type probeResponse struct {
@@ -158,105 +158,139 @@ func writeTCPLine(w io.Writer, line string) error {
 	return err
 }
 
-func escapeQuoted(raw string) string {
-	raw = strings.ReplaceAll(raw, "\\", "\\\\")
-	raw = strings.ReplaceAll(raw, "\"", "\\\"")
-	return raw
-}
-
-func quoteToken(raw string) string {
-	return "\"" + escapeQuoted(raw) + "\""
-}
-
-func encodeAUTHBlobToken(blob []byte, encrypted bool) string {
-	if encrypted {
-		encoded := base64.StdEncoding.EncodeToString(blob)
-		return quoteToken("b64:" + encoded)
+func (c *Client) resolveTCPAuthState(ctx context.Context) (tcpAuthState, error) {
+	encMode := strings.ToLower(strings.TrimSpace(c.EncryptMode))
+	if encMode == "" || encMode == "none" {
+		return tcpAuthState{}, nil
 	}
-	return quoteToken(string(blob))
-}
-
-func (c *Client) resolveTCPAuthState() (tcpAuthState, error) {
-	state := tcpAuthState{encMode: c.EncryptMode}
-	if state.encMode == "" {
-		state.encMode = "age"
+	if encMode != "age" && encMode != "aes" {
+		return tcpAuthState{}, fmt.Errorf("unsupported encrypt mode: %s", encMode)
 	}
+
+	// Generate ephemeral client identity if not provided.
 	requestPub := strings.TrimSpace(c.ClientAgePublicKey)
 	requestIdentity := strings.TrimSpace(c.ClientAgeIdentity)
-	serverPub := strings.TrimSpace(c.ServerAgePublicKey)
-
-	if serverPub != "" {
-		state.hasAuth = true
-		state.encryptCommands = true
-		if requestPub == "" || requestIdentity == "" {
-			identity, err := age.GenerateX25519Identity()
-			if err != nil {
-				return tcpAuthState{}, fmt.Errorf("generate age identity: %w", err)
-			}
-			requestPub = identity.Recipient().String()
-			requestIdentity = identity.String()
-		}
-	}
-	if requestPub != "" {
-		state.hasAuth = true
-		state.publicKey = requestPub
-	}
-	if requestIdentity != "" {
-		state.identity = requestIdentity
-	}
-	if state.hasAuth && state.publicKey == "" {
-		state.publicKey = requestPub
-	}
-	if state.hasAuth && state.identity == "" {
-		return tcpAuthState{}, errors.New("missing age identity for authenticated response")
-	}
-	if state.hasAuth {
-		parsed, err := parseAgeIdentity(state.identity)
+	if requestPub == "" || requestIdentity == "" {
+		identity, err := age.GenerateX25519Identity()
 		if err != nil {
-			return tcpAuthState{}, err
+			return tcpAuthState{}, fmt.Errorf("generate age identity: %w", err)
 		}
-		state.parsedIdentity = parsed
+		requestPub = identity.Recipient().String()
+		requestIdentity = identity.String()
 	}
-	if state.encryptCommands {
-		if _, err := age.ParseX25519Recipient(serverPub); err != nil {
-			return tcpAuthState{}, fmt.Errorf("invalid PINCH_FILE_SERVER_AGE_PUBLIC_KEY: %w", err)
+
+	parsed, err := parseAgeIdentity(requestIdentity)
+	if err != nil {
+		return tcpAuthState{}, err
+	}
+
+	// Discover the server's public key via AUTH key.
+	serverKey, err := c.discoverServerKey(ctx)
+	if err != nil {
+		return tcpAuthState{}, fmt.Errorf("discover server key: %w", err)
+	}
+
+	return tcpAuthState{
+		publicKey:      requestPub,
+		identity:       requestIdentity,
+		parsedIdentity: parsed,
+		serverKey:      serverKey,
+		hasAuth:        true,
+		encMode:        encMode,
+	}, nil
+}
+
+// discoverServerKey sends AUTH key on a fresh connection and reads back the
+// server's age public key from the OK response.
+func (c *Client) discoverServerKey(ctx context.Context) (string, error) {
+	conn, err := c.dialTCP(ctx)
+	if err != nil {
+		return "", fmt.Errorf("dial for key exchange: %w", err)
+	}
+	defer conn.Close()
+	if err := writeTCPLine(conn, "AUTH key"); err != nil {
+		return "", err
+	}
+	br := bufio.NewReader(conn)
+	line, err := readTCPLine(br, maxTCPLineBytes)
+	if err != nil {
+		return "", fmt.Errorf("read key exchange response: %w", err)
+	}
+	msg, ok := parseOKStatusLine(line)
+	if !ok {
+		if lineErr := parseErrControlFrame(line); lineErr != nil {
+			return "", lineErr
 		}
+		return "", fmt.Errorf("unexpected key exchange response: %s", line)
 	}
-	return state, nil
+	key := strings.TrimSpace(msg)
+	if key == "" {
+		return "", errors.New("server returned empty public key")
+	}
+	if _, err := age.ParseX25519Recipient(key); err != nil {
+		return "", fmt.Errorf("invalid server public key: %w", err)
+	}
+	return key, nil
 }
 
 func (c *Client) sendTCPAuth(conn net.Conn, state tcpAuthState) error {
 	if !state.hasAuth {
 		return nil
 	}
-	blob := []byte(state.publicKey)
-	if state.encryptCommands {
-		recipient, err := age.ParseX25519Recipient(strings.TrimSpace(c.ServerAgePublicKey))
-		if err != nil {
-			return err
+	recipient, err := age.ParseX25519Recipient(state.serverKey)
+	if err != nil {
+		return fmt.Errorf("parse server key: %w", err)
+	}
+	// Encrypt the client's public key to the server.
+	encrypted := c.acquireScratchBuffer(0)
+	defer c.releaseScratchBuffer(encrypted)
+	switch state.encMode {
+	case "aes":
+		ew, encErr := intencoding.AESGCMEncrypt(encrypted, recipient, 0)
+		if encErr != nil {
+			return encErr
 		}
-		encrypted := c.acquireScratchBuffer(0)
-		defer c.releaseScratchBuffer(encrypted)
-		ew, err := age.Encrypt(encrypted, recipient)
-		if err != nil {
-			return err
-		}
-		if _, err := ew.Write(blob); err != nil {
+		if _, err := ew.Write([]byte(state.publicKey)); err != nil {
 			return err
 		}
 		if err := ew.Close(); err != nil {
 			return err
 		}
-		blob = encrypted.Bytes()
+	default:
+		ew, encErr := age.Encrypt(encrypted, recipient)
+		if encErr != nil {
+			return encErr
+		}
+		if _, err := ew.Write([]byte(state.publicKey)); err != nil {
+			return err
+		}
+		if err := ew.Close(); err != nil {
+			return err
+		}
 	}
-	return writeTCPLine(conn, "AUTH "+encodeAUTHBlobToken(blob, state.encryptCommands))
+	encoded := base64.StdEncoding.EncodeToString(encrypted.Bytes())
+	return writeTCPLine(conn, "AUTH "+state.encMode+" "+encoded)
+}
+
+// halfCloseWrite sends TCP FIN for the write direction only, signaling EOF to
+// the remote reader while keeping the connection open for reading responses.
+// This is required for age-encrypted requests: age's DecryptReader performs an
+// extra Read after the final chunk to confirm EOF, which would deadlock on a
+// duplex connection that stays open.
+func halfCloseWrite(conn net.Conn) {
+	type writeHalfCloser interface {
+		CloseWrite() error
+	}
+	if wc, ok := conn.(writeHalfCloser); ok {
+		_ = wc.CloseWrite()
+	}
 }
 
 func (c *Client) sendTCPCommand(conn net.Conn, state tcpAuthState, payload string) error {
-	if !state.encryptCommands {
+	if !state.hasAuth {
 		return writeTCPLine(conn, payload)
 	}
-	recipient, err := age.ParseX25519Recipient(strings.TrimSpace(c.ServerAgePublicKey))
+	recipient, err := age.ParseX25519Recipient(state.serverKey)
 	if err != nil {
 		return err
 	}
@@ -271,9 +305,14 @@ func (c *Client) sendTCPCommand(conn net.Conn, state tcpAuthState, payload strin
 		return err
 	}
 	if err := writeTCPLine(ew, payload); err != nil {
+		_ = ew.Close()
 		return err
 	}
-	return ew.Close()
+	if err := ew.Close(); err != nil {
+		return err
+	}
+	halfCloseWrite(conn)
+	return nil
 }
 
 func (c *Client) responseReaderForTCP(conn net.Conn, state tcpAuthState) (io.Reader, error) {
@@ -286,9 +325,9 @@ func (c *Client) responseReaderForTCP(conn net.Conn, state tcpAuthState) (io.Rea
 	}
 	switch state.encMode {
 	case "aes":
-		decReader, err := intencoding.AESGCMDecrypt(conn, identity, 0)
+		decReader, err := intencoding.AESGCMDecrypt(conn, identity)
 		if err != nil {
-			return nil, fmt.Errorf("decryption failed: ensure client and server use the same --encrypt mode (age or aes): %w", err)
+			return nil, fmt.Errorf("aes decryption failed: %w", err)
 		}
 		return decReader, nil
 	default:
@@ -301,7 +340,7 @@ func (c *Client) responseReaderForTCP(conn net.Conn, state tcpAuthState) (io.Rea
 }
 
 func (c *Client) getManifestTCP(ctx context.Context, request GetManifestRequest) (GetManifestResponse, error) {
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return GetManifestResponse{}, err
 	}
@@ -361,7 +400,7 @@ func (c *Client) getManifestTCP(ctx context.Context, request GetManifestRequest)
 }
 
 func (c *Client) syncManifestTCP(ctx context.Context, request SyncManifestRequest) (SyncManifestResponse, error) {
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return SyncManifestResponse{}, err
 	}
@@ -467,7 +506,7 @@ func (c *Client) fetchFileWindowTCP(
 	if fullPath == "" {
 		return nil, nil, errors.New("missing full path")
 	}
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -556,7 +595,7 @@ func (c *Client) fetchFileBatchTCP(
 	if len(targets) == 0 {
 		return nil, errors.New("missing file targets")
 	}
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -648,7 +687,7 @@ func (c *Client) probeTCP(ctx context.Context, probeBytes int64) (probeResponse,
 	if probeBytes <= 0 {
 		return probeResponse{}, errors.New("probe bytes must be > 0")
 	}
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return probeResponse{}, err
 	}
@@ -702,14 +741,14 @@ func (c *Client) probeTCP(ctx context.Context, probeBytes int64) (probeResponse,
 }
 
 func (c *Client) sendTCPProbe(conn net.Conn, state tcpAuthState, cmd string, probeBytes int64) error {
-	if !state.encryptCommands {
+	if !state.hasAuth {
 		if err := writeTCPLine(conn, cmd); err != nil {
 			return err
 		}
 		_, err := io.CopyN(conn, rand.Reader, probeBytes)
 		return err
 	}
-	recipient, err := age.ParseX25519Recipient(strings.TrimSpace(c.ServerAgePublicKey))
+	recipient, err := age.ParseX25519Recipient(state.serverKey)
 	if err != nil {
 		return err
 	}
@@ -731,7 +770,11 @@ func (c *Client) sendTCPProbe(conn net.Conn, state tcpAuthState, cmd string, pro
 		_ = ew.Close()
 		return err
 	}
-	return ew.Close()
+	if err := ew.Close(); err != nil {
+		return err
+	}
+	halfCloseWrite(conn)
+	return nil
 }
 
 type firstReadTimestampReader struct {
@@ -816,7 +859,7 @@ func (c *Client) acknowledgeFileProgressBatchTCP(ctx context.Context, commands [
 	if txferID == "" {
 		return AcknowledgeFileProgressResponse{}, errors.New("missing transfer id")
 	}
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return AcknowledgeFileProgressResponse{}, err
 	}
@@ -866,7 +909,7 @@ func (c *Client) acknowledgeFileProgressBatchTCP(ctx context.Context, commands [
 }
 
 func (c *Client) getStatusTCP(ctx context.Context, request GetStatusRequest) (GetStatusResponse, error) {
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return GetStatusResponse{}, err
 	}
@@ -902,7 +945,7 @@ func (c *Client) getStatusTCP(ctx context.Context, request GetStatusRequest) (Ge
 }
 
 func (c *Client) listStatusesTCP(ctx context.Context, request ListStatusesRequest) (ListStatusesResponse, error) {
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return ListStatusesResponse{}, err
 	}
@@ -948,7 +991,7 @@ func (c *Client) listStatusesTCP(ctx context.Context, request ListStatusesReques
 }
 
 func (c *Client) getChecksumTCP(ctx context.Context, request GetChecksumRequest) (io.ReadCloser, error) {
-	state, err := c.resolveTCPAuthState()
+	state, err := c.resolveTCPAuthState(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/server/filexfer/client_test.go
+++ b/server/filexfer/client_test.go
@@ -148,12 +148,10 @@ func readCompatLine(br *bufio.Reader) (string, error) {
 }
 
 func TestNewClientOptions(t *testing.T) {
-	t.Setenv("PINCH_FILE_SERVER_AGE_PUBLIC_KEY", "age1envvalue")
 	dialer := func(context.Context, string) (net.Conn, error) { return nil, errors.New("unused") }
 
 	client := NewClient(
 		" 127.0.0.1:3453 ",
-		WithServerAgePublicKey(""),
 		WithFileRequestWindowBytes(123),
 		WithFrameBufferBytes(456),
 		WithMaxFrameReadBufferBytes(789),
@@ -164,9 +162,6 @@ func TestNewClientOptions(t *testing.T) {
 
 	if client.FileAddr != "127.0.0.1:3453" {
 		t.Fatalf("unexpected file addr: %q", client.FileAddr)
-	}
-	if client.ServerAgePublicKey != "" {
-		t.Fatalf("expected option to override env, got %q", client.ServerAgePublicKey)
 	}
 	if client.FileRequestWindowBytes != 123 {
 		t.Fatalf("unexpected file request window bytes: %d", client.FileRequestWindowBytes)
@@ -1723,7 +1718,7 @@ func TestClientUsesInjectedDialContext(t *testing.T) {
 		}()
 		return clientConn, nil
 	}
-	client := NewClient("ignored:0", WithContextDialer(dialContext), WithServerAgePublicKey(""))
+	client := NewClient("ignored:0", WithContextDialer(dialContext))
 
 	resp, err := client.GetStatus(context.Background(), GetStatusRequest{TransferID: "tx123"})
 	if err != nil {

--- a/server/filexfer/docs/PROTOCOL.md
+++ b/server/filexfer/docs/PROTOCOL.md
@@ -52,28 +52,34 @@ For this line protocol, token bytes cannot span command newlines.
 
 ### Request
 
-- `AUTH`
-- `AUTH <blob>`
+Three forms:
 
-`<blob>` can be quoted or length-prefixed.
+- `AUTH key` — key exchange: server returns its age public key.
+- `AUTH age <blob>` — age encryption: blob is the client's age public key encrypted with age to the server's public key.
+- `AUTH aes <blob>` — AES-GCM encryption: blob is the client's age public key encrypted with AES-GCM to the server's public key.
 
-### Behavior
+`<blob>` is length-prefixed (`<len>:<bytes>`).
 
-When `-fs-require-auth=true`:
+### Key Exchange Flow
 
-- blob must decode to age ciphertext decryptable by server identity.
-- decrypted plaintext must be client age recipient string.
-- if valid:
-  - subsequent response bytes are age-encrypted to client recipient.
-  - subsequent command line must be age-encrypted to server identity.
-- if invalid: `ERR NOT_AUTHORIZED authorization failed`.
+1. Client sends `AUTH key\r\n`.
+2. Server responds `OK <server-age-public-key>\r\n` and closes the connection.
+3. Client opens a new connection and sends `AUTH age <blob>\r\n` or `AUTH aes <blob>\r\n`.
 
-When `-fs-require-auth=false`:
+### Encrypted Connection Flow
 
-- empty `AUTH` is accepted (no encryption).
-- non-empty blob must be a plaintext age recipient string.
-- server encrypts responses to that recipient.
-- command line remains plaintext.
+After `AUTH age <blob>` or `AUTH aes <blob>`:
+
+- Server decrypts blob using its identity to recover the client's age public key.
+- If valid:
+  - subsequent response bytes are encrypted to the client's public key using the selected cipher (age or AES-GCM).
+  - subsequent command bytes from the client must be encrypted to the server's public key using the same cipher.
+- If invalid: `ERR NOT_AUTHORIZED authorization failed`.
+
+### Unencrypted Connection Flow
+
+When no encryption is desired, the client omits AUTH entirely and sends the
+command directly.
 
 ## TXFER
 

--- a/server/internal/cmd/filexfercli/cli_test.go
+++ b/server/internal/cmd/filexfercli/cli_test.go
@@ -3,6 +3,7 @@ package filexfercli
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -39,10 +40,10 @@ func (s *ftcpTestServer) Close() {
 }
 
 func newFTCPTestServer(t *testing.T, handler func(intftcp.Request, io.Writer) error) *ftcpTestServer {
-	return newFTCPTestServerWithEncryptMode(t, "", handler)
+	return newFTCPTestServerWithIdentity(t, nil, handler)
 }
 
-func newFTCPTestServerWithEncryptMode(t *testing.T, encryptMode string, handler func(intftcp.Request, io.Writer) error) *ftcpTestServer {
+func newFTCPTestServerWithIdentity(t *testing.T, serverID *age.X25519Identity, handler func(intftcp.Request, io.Writer) error) *ftcpTestServer {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -61,14 +62,14 @@ func newFTCPTestServerWithEncryptMode(t *testing.T, encryptMode string, handler 
 			go func(c net.Conn) {
 				defer s.wg.Done()
 				defer c.Close()
-				serveFTCPConn(c, encryptMode, handler)
+				serveFTCPConn(c, serverID, handler)
 			}(conn)
 		}
 	}()
 	return s
 }
 
-func serveFTCPConn(conn net.Conn, encryptMode string, handler func(intftcp.Request, io.Writer) error) {
+func serveFTCPConn(conn net.Conn, serverID *age.X25519Identity, handler func(intftcp.Request, io.Writer) error) {
 	br := bufio.NewReader(conn)
 	firstLine, err := readFTCPLine(br)
 	if err != nil {
@@ -84,26 +85,90 @@ func serveFTCPConn(conn net.Conn, encryptMode string, handler func(intftcp.Reque
 	closeOut := func() error { return nil }
 	cmdReq := req
 	if req.Verb == intftcp.VerbAUTH {
-		if len(req.Params) > 0 {
-			blob := strings.TrimSpace(req.Params[0]["blob"])
-			if blob != "" {
-				if recipient, parseErr := age.ParseX25519Recipient(blob); parseErr == nil {
-					var ew io.WriteCloser
-					var encErr error
-					switch encryptMode {
-					case "aes":
-						ew, encErr = encoding.AESGCMEncrypt(conn, recipient, 0)
-					default:
-						ew, encErr = age.Encrypt(conn, recipient)
-					}
-					if encErr != nil {
-						return
-					}
-					out = ew
-					closeOut = ew.Close
-				}
-			}
+		if len(req.Params) == 0 {
+			_, _ = io.WriteString(conn, "ERR BAD_AUTH missing protocol\r\n")
+			return
 		}
+		protocol := req.Params[0]["protocol"]
+
+		if protocol == "key" {
+			// Key exchange: return server public key and close.
+			if serverID == nil {
+				_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED no server identity\r\n")
+				return
+			}
+			_, _ = io.WriteString(conn, "OK "+serverID.Recipient().String()+"\r\n")
+			return
+		}
+
+		// age or aes: decode and decrypt the blob to get the client's public key.
+		blobRaw := req.Params[0]["blob"]
+		if blobRaw == "" || serverID == nil {
+			_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
+			return
+		}
+		blobBytes, b64Err := base64.StdEncoding.DecodeString(strings.TrimSpace(blobRaw))
+		if b64Err != nil {
+			_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED bad base64\r\n")
+			return
+		}
+		var plain []byte
+		switch protocol {
+		case "aes":
+			dec, decErr := encoding.AESGCMDecrypt(bytes.NewReader(blobBytes), serverID)
+			if decErr != nil {
+				_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
+				return
+			}
+			plain, err = io.ReadAll(dec)
+		default:
+			dec, decErr := age.Decrypt(bytes.NewReader(blobBytes), serverID)
+			if decErr != nil {
+				_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
+				return
+			}
+			plain, err = io.ReadAll(dec)
+		}
+		if err != nil {
+			_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
+			return
+		}
+		recipient, parseErr := age.ParseX25519Recipient(strings.TrimSpace(string(plain)))
+		if parseErr != nil {
+			_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
+			return
+		}
+
+		// Encrypt responses to client.
+		var ew io.WriteCloser
+		var encErr error
+		switch protocol {
+		case "aes":
+			ew, encErr = encoding.AESGCMEncrypt(conn, recipient, 0)
+		default:
+			ew, encErr = age.Encrypt(conn, recipient)
+		}
+		if encErr != nil {
+			return
+		}
+		out = ew
+		closeOut = ew.Close
+
+		// Decrypt the command from client.
+		var cmdReader io.Reader
+		switch protocol {
+		case "aes":
+			cmdReader, err = encoding.AESGCMDecrypt(br, serverID)
+		default:
+			cmdReader, err = age.Decrypt(br, serverID)
+		}
+		if err != nil {
+			_, _ = io.WriteString(out, "ERR NOT_AUTHORIZED request decryption failed\r\n")
+			_ = closeOut()
+			return
+		}
+		br = bufio.NewReader(cmdReader)
+
 		cmdLine, cmdErr := readFTCPLine(br)
 		if cmdErr != nil {
 			_, _ = io.WriteString(out, "ERR BAD_REQUEST missing command\r\n")
@@ -437,7 +502,11 @@ func TestRunCLITransferWithEncryptAge(t *testing.T) {
 		"",
 	}, "\n")
 
-	srv := newFTCPTestServer(t, func(req intftcp.Request, out io.Writer) error {
+	serverID, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate server identity: %v", err)
+	}
+	srv := newFTCPTestServerWithIdentity(t, serverID, func(req intftcp.Request, out io.Writer) error {
 		switch req.Verb {
 		case intftcp.VerbPROBE:
 			cts0 := req.Params[0]["cts0"]
@@ -492,7 +561,11 @@ func TestRunCLITransferWithEncryptAES(t *testing.T) {
 		"",
 	}, "\n")
 
-	srv := newFTCPTestServerWithEncryptMode(t, "aes", func(req intftcp.Request, out io.Writer) error {
+	serverID, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate server identity: %v", err)
+	}
+	srv := newFTCPTestServerWithIdentity(t, serverID, func(req intftcp.Request, out io.Writer) error {
 		switch req.Verb {
 		case intftcp.VerbPROBE:
 			cts0 := req.Params[0]["cts0"]

--- a/server/internal/filexfer/encoding/aead.go
+++ b/server/internal/filexfer/encoding/aead.go
@@ -26,9 +26,11 @@ const (
 	aeadVersion      = 0x01
 )
 
+const aeadMaxAADChunkCount = ^uint64(0) >> 1
+
 var aeadBufferPools sync.Map // map[int]*sync.Pool
 
-// AESGCMEncrypt creates a streaming AES-256-GCM encrypted writer. It performs
+// AESGCMEncrypt creates a streaming AES-GCM encrypted writer. It performs
 // X25519 key exchange via the recipient's Wrap method (compatible with
 // age.X25519Recipient), writes a binary key-exchange header to dst, then
 // returns a WriteCloser that encrypts data in fixed-size chunks.
@@ -58,7 +60,9 @@ func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.Wr
 		return nil, fmt.Errorf("expected 1 stanza from Wrap, got %d", len(stanzas))
 	}
 
-	if err := writeStanzaHeader(dst, stanzas[0]); err != nil {
+	chunkSize = normalizeAEADChunkSize(chunkSize)
+
+	if err := writeStanzaHeader(dst, stanzas[0], chunkSize); err != nil {
 		return nil, fmt.Errorf("write stanza header: %w", err)
 	}
 
@@ -81,15 +85,13 @@ func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.Wr
 	}, nil
 }
 
-// AESGCMDecrypt creates a streaming AES-256-GCM decrypting reader. It reads
+// AESGCMDecrypt creates a streaming AES-GCM decrypting reader. It reads
 // the key-exchange header from src, recovers the file key via the identity's
 // Unwrap method (compatible with age.X25519Identity), then returns a Reader
 // that decrypts chunks on the fly.
 //
-// chunkSize is the plaintext chunk size in bytes. A non-positive value uses the
-// default size. Values smaller than 1 KiB are clamped upward.
 // Not goroutine-safe.
-func AESGCMDecrypt(src io.Reader, identity age.Identity, chunkSize int) (io.Reader, error) {
+func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 	if src == nil {
 		return nil, errors.New("nil source reader")
 	}
@@ -97,7 +99,7 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity, chunkSize int) (io.Read
 		return nil, errors.New("nil identity")
 	}
 
-	stanza, err := readStanzaHeader(src)
+	stanza, chunkSize, err := readStanzaHeader(src)
 	if err != nil {
 		return nil, fmt.Errorf("read stanza header: %w", err)
 	}
@@ -126,7 +128,7 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity, chunkSize int) (io.Read
 	}, nil
 }
 
-// newGCM derives an AES-256 key from the file key via HKDF-SHA256 and
+// newGCM derives an AES-256 key from the age file key via HKDF-SHA256 and
 // returns a GCM cipher instance.
 func newGCM(fileKey []byte) (cipher.AEAD, error) {
 	hk := hkdf.New(sha256.New, fileKey, nil, []byte(aeadHKDFInfo))
@@ -155,6 +157,20 @@ func acquireAEADBuffer(chunkSize int) ([]byte, int, func()) {
 		clear(buf)
 		pool.Put(buf[:bufSize])
 	}
+}
+
+func writeFull(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		p = p[n:]
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
 }
 
 func normalizeAEADChunkSize(chunkSize int) int {
@@ -189,9 +205,10 @@ func aeadBufferPool(size int) *sync.Pool {
 //   [2 bytes BE: num_args]
 //     per arg: [2 bytes BE: arg_len][arg_len bytes: arg]
 //   [2 bytes BE: body_len][body_len bytes: Stanza.Body]
+//   [4 bytes BE: chunk_size]
 
-func writeStanzaHeader(w io.Writer, s *age.Stanza) error {
-	if _, err := w.Write([]byte{aeadVersion}); err != nil {
+func writeStanzaHeader(w io.Writer, s *age.Stanza, chunkSize int) error {
+	if err := writeFull(w, []byte{aeadVersion}); err != nil {
 		return err
 	}
 	if err := writeU16Prefixed(w, []byte(s.Type)); err != nil {
@@ -199,7 +216,7 @@ func writeStanzaHeader(w io.Writer, s *age.Stanza) error {
 	}
 	var numArgs [2]byte
 	binary.BigEndian.PutUint16(numArgs[:], uint16(len(s.Args)))
-	if _, err := w.Write(numArgs[:]); err != nil {
+	if err := writeFull(w, numArgs[:]); err != nil {
 		return err
 	}
 	for _, arg := range s.Args {
@@ -207,46 +224,60 @@ func writeStanzaHeader(w io.Writer, s *age.Stanza) error {
 			return err
 		}
 	}
-	return writeU16Prefixed(w, s.Body)
+	if err := writeU16Prefixed(w, s.Body); err != nil {
+		return err
+	}
+	var chunkSizeBuf [4]byte
+	binary.BigEndian.PutUint32(chunkSizeBuf[:], uint32(chunkSize))
+	return writeFull(w, chunkSizeBuf[:])
 }
 
-func readStanzaHeader(r io.Reader) (*age.Stanza, error) {
+func readStanzaHeader(r io.Reader) (*age.Stanza, int, error) {
 	var ver [1]byte
 	if _, err := io.ReadFull(r, ver[:]); err != nil {
-		return nil, fmt.Errorf("read version: %w", err)
+		return nil, 0, fmt.Errorf("read version: %w", err)
 	}
 	if ver[0] != aeadVersion {
-		return nil, fmt.Errorf("unsupported AEAD version: %d", ver[0])
+		return nil, 0, fmt.Errorf("unsupported AEAD version: %d", ver[0])
 	}
 
 	typ, err := readU16Prefixed(r)
 	if err != nil {
-		return nil, fmt.Errorf("read stanza type: %w", err)
+		return nil, 0, fmt.Errorf("read stanza type: %w", err)
 	}
 	if string(typ) != "X25519" {
-		return nil, fmt.Errorf("unsupported stanza type: %q", string(typ))
+		return nil, 0, fmt.Errorf("unsupported stanza type: %q", string(typ))
 	}
 
 	var numArgsBuf [2]byte
 	if _, err := io.ReadFull(r, numArgsBuf[:]); err != nil {
-		return nil, fmt.Errorf("read num_args: %w", err)
+		return nil, 0, fmt.Errorf("read num_args: %w", err)
 	}
 	numArgs := int(binary.BigEndian.Uint16(numArgsBuf[:]))
 	args := make([]string, numArgs)
 	for i := range args {
 		a, err := readU16Prefixed(r)
 		if err != nil {
-			return nil, fmt.Errorf("read arg %d: %w", i, err)
+			return nil, 0, fmt.Errorf("read arg %d: %w", i, err)
 		}
 		args[i] = string(a)
 	}
 
 	body, err := readU16Prefixed(r)
 	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
+		return nil, 0, fmt.Errorf("read body: %w", err)
 	}
 
-	return &age.Stanza{Type: string(typ), Args: args, Body: body}, nil
+	var chunkSizeBuf [4]byte
+	if _, err := io.ReadFull(r, chunkSizeBuf[:]); err != nil {
+		return nil, 0, fmt.Errorf("read chunk size: %w", err)
+	}
+	chunkSize := int(binary.BigEndian.Uint32(chunkSizeBuf[:]))
+	if chunkSize < aeadMinChunkSize {
+		return nil, 0, fmt.Errorf("invalid AEAD chunk size: %d", chunkSize)
+	}
+
+	return &age.Stanza{Type: string(typ), Args: args, Body: body}, chunkSize, nil
 }
 
 func writeU16Prefixed(w io.Writer, data []byte) error {
@@ -255,12 +286,11 @@ func writeU16Prefixed(w io.Writer, data []byte) error {
 	}
 	var buf [2]byte
 	binary.BigEndian.PutUint16(buf[:], uint16(len(data)))
-	if _, err := w.Write(buf[:]); err != nil {
+	if err := writeFull(w, buf[:]); err != nil {
 		return err
 	}
 	if len(data) > 0 {
-		_, err := w.Write(data)
-		return err
+		return writeFull(w, data)
 	}
 	return nil
 }
@@ -284,8 +314,8 @@ func readU16Prefixed(r io.Reader) ([]byte, error) {
 // ---------------------------------------------------------------------------
 //
 // Nonce layout (12 bytes):
-//   bytes 0–2:  zero (high bits of counter, never reached in practice)
-//   bytes 3–10: big-endian uint64 counter
+//   bytes 0–2:  zero (high bits of chunk count, never reached in practice)
+//   bytes 3–10: big-endian uint64 chunk count
 //   byte 11:    0x00 = non-final chunk, 0x01 = final chunk
 
 type aesgcmWriter struct {
@@ -298,7 +328,7 @@ type aesgcmWriter struct {
 	plainN     int // bytes currently in plainBuf
 	chunkSize  int
 	nonce      [aeadNonceSize]byte
-	counter    uint64
+	chunkCount uint64
 	err        error
 	closed     bool
 }
@@ -343,17 +373,21 @@ func (w *aesgcmWriter) Close() error {
 
 func (w *aesgcmWriter) flushChunk(last bool) error {
 	w.buildNonce(last)
-	sealed := w.gcm.Seal(w.sealBuf[:0], w.nonce[:], w.plainBuf[:w.plainN], nil)
-	if _, err := w.dst.Write(sealed); err != nil {
+	aad, err := buildChunkAAD(w.chunkSize, w.chunkCount, last)
+	if err != nil {
+		return err
+	}
+	sealed := w.gcm.Seal(w.sealBuf[:0], w.nonce[:], w.plainBuf[:w.plainN], aad[:])
+	if err := writeFull(w.dst, sealed); err != nil {
 		return err
 	}
 	w.plainN = 0
-	w.counter++
+	w.chunkCount++
 	return nil
 }
 
 func (w *aesgcmWriter) buildNonce(last bool) {
-	binary.BigEndian.PutUint64(w.nonce[3:11], w.counter)
+	binary.BigEndian.PutUint64(w.nonce[3:11], w.chunkCount)
 	if last {
 		w.nonce[11] = 0x01
 	} else {
@@ -386,7 +420,7 @@ type aesgcmReader struct {
 	unread     []byte // unconsumed plaintext, subslice of plainBuf
 	chunkSize  int
 	nonce      [aeadNonceSize]byte
-	counter    uint64
+	chunkCount uint64
 	err        error
 	done       bool
 }
@@ -430,34 +464,46 @@ func (r *aesgcmReader) readChunk() error {
 	case err == nil:
 		// Full-size read. Try non-final nonce first.
 		r.buildNonce(false)
-		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], nil)
+		aad, aadErr := buildChunkAAD(r.chunkSize, r.chunkCount, false)
+		if aadErr != nil {
+			return aadErr
+		}
+		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr == nil {
 			r.unread = plaintext
-			r.counter++
+			r.chunkCount++
 			return nil
 		}
 		// Non-final failed — this may be a final chunk that happens to be
 		// exactly chunkSize bytes of plaintext.
 		r.buildNonce(true)
-		plaintext, openErr = r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], nil)
+		aad, aadErr = buildChunkAAD(r.chunkSize, r.chunkCount, true)
+		if aadErr != nil {
+			return aadErr
+		}
+		plaintext, openErr = r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr != nil {
 			return fmt.Errorf("AEAD authentication failed: %w", openErr)
 		}
 		r.unread = plaintext
 		r.done = true
-		r.counter++
+		r.chunkCount++
 		return nil
 
 	case errors.Is(err, io.ErrUnexpectedEOF) && n > 0:
 		// Short read — must be the final (possibly short) chunk.
 		r.buildNonce(true)
-		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], nil)
+		aad, aadErr := buildChunkAAD(r.chunkSize, r.chunkCount, true)
+		if aadErr != nil {
+			return aadErr
+		}
+		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr != nil {
 			return fmt.Errorf("AEAD authentication failed on final chunk: %w", openErr)
 		}
 		r.unread = plaintext
 		r.done = true
-		r.counter++
+		r.chunkCount++
 		return nil
 
 	case errors.Is(err, io.EOF) && n == 0:
@@ -470,7 +516,7 @@ func (r *aesgcmReader) readChunk() error {
 }
 
 func (r *aesgcmReader) buildNonce(last bool) {
-	binary.BigEndian.PutUint64(r.nonce[3:11], r.counter)
+	binary.BigEndian.PutUint64(r.nonce[3:11], r.chunkCount)
 	if last {
 		r.nonce[11] = 0x01
 	} else {
@@ -488,4 +534,19 @@ func (r *aesgcmReader) release() {
 	r.backingBuf = nil
 	r.cipherBuf = nil
 	r.plainBuf = nil
+}
+
+func buildChunkAAD(chunkSize int, chunkCount uint64, last bool) ([13]byte, error) {
+	var aad [13]byte
+	if chunkCount > aeadMaxAADChunkCount {
+		return aad, errors.New("AEAD chunk count exceeded int64 AAD range")
+	}
+	binary.BigEndian.PutUint32(aad[1:5], uint32(chunkSize))
+	signedChunkCount := int64(chunkCount)
+	if last {
+		signedChunkCount = ^signedChunkCount
+	}
+	aad[0] = aeadVersion
+	binary.BigEndian.PutUint64(aad[5:13], uint64(signedChunkCount))
+	return aad, nil
 }

--- a/server/internal/filexfer/encoding/aead_test.go
+++ b/server/internal/filexfer/encoding/aead_test.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/binary"
 	"io"
 	"testing"
 
@@ -34,7 +35,7 @@ func roundTrip(t testing.TB, plaintext []byte, chunkSize int) {
 		t.Fatalf("close: %v", err)
 	}
 
-	r, err := AESGCMDecrypt(&ciphertext, id, chunkSize)
+	r, err := AESGCMDecrypt(&ciphertext, id)
 	if err != nil {
 		t.Fatalf("decrypt: %v", err)
 	}
@@ -96,7 +97,7 @@ func TestAESGCMTampered(t *testing.T) {
 	}
 	raw[len(raw)-10] ^= 0x01
 
-	r, err := AESGCMDecrypt(bytes.NewReader(raw), id, 0)
+	r, err := AESGCMDecrypt(bytes.NewReader(raw), id)
 	if err != nil {
 		t.Fatalf("decrypt init: %v", err)
 	}
@@ -118,7 +119,7 @@ func TestAESGCMWrongKey(t *testing.T) {
 	w.Write(plaintext)
 	w.Close()
 
-	_, err = AESGCMDecrypt(&ciphertext, wrongID, 0)
+	_, err = AESGCMDecrypt(&ciphertext, wrongID)
 	if err == nil {
 		t.Fatal("expected error decrypting with wrong identity")
 	}
@@ -140,7 +141,7 @@ func TestAESGCMTruncated(t *testing.T) {
 
 	// Truncate to half the ciphertext.
 	truncated := ciphertext.Bytes()[:ciphertext.Len()/2]
-	r, err := AESGCMDecrypt(bytes.NewReader(truncated), id, 0)
+	r, err := AESGCMDecrypt(bytes.NewReader(truncated), id)
 	if err != nil {
 		t.Fatalf("decrypt init: %v", err)
 	}
@@ -153,6 +154,162 @@ func TestAESGCMDefaultChunkSize(t *testing.T) {
 	data := make([]byte, 100*1024)
 	rand.Read(data)
 	roundTrip(t, data, 0)
+}
+
+func TestAESGCMChunkSizeFromHeader(t *testing.T) {
+	data := make([]byte, 100*1024)
+	rand.Read(data)
+	roundTrip(t, data, 4*1024)
+}
+
+func TestAESGCMHeaderChunkSizeTamper(t *testing.T) {
+	id, recipient := generateTestIdentity(t)
+
+	var ciphertext bytes.Buffer
+	w, err := AESGCMEncrypt(&ciphertext, recipient, 4*1024)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if _, err := w.Write([]byte("tamper me")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	raw := ciphertext.Bytes()
+	offset := stanzaChunkSizeOffset(t, raw)
+	binary.BigEndian.PutUint32(raw[offset:offset+4], 8*1024)
+
+	r, err := AESGCMDecrypt(bytes.NewReader(raw), id)
+	if err != nil {
+		t.Fatalf("decrypt init: %v", err)
+	}
+	if _, err := io.ReadAll(r); err == nil {
+		t.Fatal("expected authentication error for tampered chunk size")
+	}
+}
+
+var aeadBenchSizes = []struct {
+	name string
+	n    int
+}{
+	{"64KiB", 64 << 10},
+	{"1MiB", 1 << 20},
+	{"4MiB", 4 << 20},
+	{"10MiB", 10 << 20},
+}
+
+func BenchmarkEncryptThroughput(b *testing.B) {
+	_, recipient := generateTestIdentity(b)
+	for _, sz := range aeadBenchSizes {
+		data := make([]byte, sz.n)
+		rand.Read(data)
+		b.Run(sz.name+"/aesgcm", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				w, err := AESGCMEncrypt(io.Discard, recipient, 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := w.Write(data); err != nil {
+					b.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+		})
+		b.Run(sz.name+"/age", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				w, err := age.Encrypt(io.Discard, recipient)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := w.Write(data); err != nil {
+					b.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+		})
+	}
+}
+
+func BenchmarkDecryptThroughput(b *testing.B) {
+	id, recipient := generateTestIdentity(b)
+	for _, sz := range aeadBenchSizes {
+		data := make([]byte, sz.n)
+		rand.Read(data)
+		aesCT := encryptAESForBench(b, data, recipient)
+		ageCT := encryptAgeForBench(b, data, recipient)
+		b.Run(sz.name+"/aesgcm", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r, err := AESGCMDecrypt(bytes.NewReader(aesCT), id)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := io.Copy(io.Discard, r); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+		})
+		b.Run(sz.name+"/age", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r, err := age.Decrypt(bytes.NewReader(ageCT), id)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := io.Copy(io.Discard, r); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+		})
+	}
+}
+
+func encryptAESForBench(b *testing.B, plaintext []byte, recipient *age.X25519Recipient) []byte {
+	b.Helper()
+	var buf bytes.Buffer
+	w, err := AESGCMEncrypt(&buf, recipient, 0)
+	if err != nil {
+		b.Fatalf("aes encrypt setup: %v", err)
+	}
+	if _, err := w.Write(plaintext); err != nil {
+		b.Fatalf("aes encrypt write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatalf("aes encrypt close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func encryptAgeForBench(b *testing.B, plaintext []byte, recipient *age.X25519Recipient) []byte {
+	b.Helper()
+	var buf bytes.Buffer
+	w, err := age.Encrypt(&buf, recipient)
+	if err != nil {
+		b.Fatalf("age encrypt setup: %v", err)
+	}
+	if _, err := w.Write(plaintext); err != nil {
+		b.Fatalf("age encrypt write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatalf("age encrypt close: %v", err)
+	}
+	return buf.Bytes()
 }
 
 func BenchmarkAESGCMEncrypt(b *testing.B) {
@@ -197,7 +354,7 @@ func BenchmarkAESGCMDecrypt(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		r, err := AESGCMDecrypt(bytes.NewReader(cipherBytes), id, aeadDefaultChunk)
+		r, err := AESGCMDecrypt(bytes.NewReader(cipherBytes), id)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -211,4 +368,44 @@ func BenchmarkAESGCMDecrypt(b *testing.B) {
 			}
 		}
 	}
+}
+
+func stanzaChunkSizeOffset(t testing.TB, ciphertext []byte) int {
+	t.Helper()
+	offset := 0
+	if len(ciphertext) < 1 {
+		t.Fatal("ciphertext too short")
+	}
+	offset++
+
+	readU16 := func() int {
+		if offset+2 > len(ciphertext) {
+			t.Fatal("ciphertext missing u16 field")
+		}
+		n := int(binary.BigEndian.Uint16(ciphertext[offset : offset+2]))
+		offset += 2
+		return n
+	}
+
+	typeLen := readU16()
+	offset += typeLen
+	if offset > len(ciphertext) {
+		t.Fatal("ciphertext missing stanza type")
+	}
+
+	numArgs := readU16()
+	for range numArgs {
+		argLen := readU16()
+		offset += argLen
+		if offset > len(ciphertext) {
+			t.Fatal("ciphertext missing stanza arg")
+		}
+	}
+
+	bodyLen := readU16()
+	offset += bodyLen
+	if offset+4 > len(ciphertext) {
+		t.Fatal("ciphertext missing chunk size")
+	}
+	return offset
 }

--- a/server/internal/filexfer/ftcp/auth.go
+++ b/server/internal/filexfer/ftcp/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"filippo.io/age"
+	"github.com/jolynch/pinch/internal/filexfer/encoding"
 )
 
 var errNotAuthorized = errors.New("not authorized")
@@ -16,31 +17,39 @@ var errNotAuthorized = errors.New("not authorized")
 type authResult struct {
 	recipient         age.Recipient
 	encryptedRequests bool
+	encryptMode       string // "age" or "aes"
+	keyExchange       bool   // true for AUTH key — server should return its public key
 }
 
-func processAUTHRequest(req Request, requireAuth bool, serverID *age.X25519Identity) (authResult, error) {
+func processAUTHRequest(req Request, serverID *age.X25519Identity) (authResult, error) {
 	if req.Verb != VerbAUTH {
 		return authResult{}, protocolErr{code: "BAD_COMMAND", message: "invalid auth command"}
 	}
-	blob := ""
-	if len(req.Params) > 0 {
-		blob = req.Params[0]["blob"]
+	if len(req.Params) == 0 {
+		return authResult{}, protocolErr{code: "BAD_AUTH", message: "missing auth protocol"}
 	}
-	if strings.TrimSpace(blob) == "" {
-		if requireAuth {
-			return authResult{}, errNotAuthorized
+	protocol := req.Params[0]["protocol"]
+
+	switch protocol {
+	case "key":
+		if serverID == nil {
+			return authResult{}, protocolErr{code: "NOT_AUTHORIZED", message: "server has no identity"}
 		}
-		return authResult{}, nil
-	}
-	if requireAuth {
+		return authResult{keyExchange: true}, nil
+
+	case "age":
 		if serverID == nil {
 			return authResult{}, errNotAuthorized
 		}
-		cipherBlob, err := decodeAUTHBlob(blob)
-		if err != nil {
+		blob := req.Params[0]["blob"]
+		if strings.TrimSpace(blob) == "" {
 			return authResult{}, errNotAuthorized
 		}
-		dec, err := age.Decrypt(bytes.NewReader(cipherBlob), serverID)
+		blobBytes, b64Err := decodeAuthBlob(blob)
+		if b64Err != nil {
+			return authResult{}, errNotAuthorized
+		}
+		dec, err := age.Decrypt(bytes.NewReader(blobBytes), serverID)
 		if err != nil {
 			return authResult{}, errNotAuthorized
 		}
@@ -56,23 +65,49 @@ func processAUTHRequest(req Request, requireAuth bool, serverID *age.X25519Ident
 		if err != nil {
 			return authResult{}, errNotAuthorized
 		}
-		return authResult{recipient: recipient, encryptedRequests: true}, nil
+		return authResult{recipient: recipient, encryptedRequests: true, encryptMode: "age"}, nil
+
+	case "aes":
+		if serverID == nil {
+			return authResult{}, errNotAuthorized
+		}
+		blob := req.Params[0]["blob"]
+		if strings.TrimSpace(blob) == "" {
+			return authResult{}, errNotAuthorized
+		}
+		blobBytes, b64Err := decodeAuthBlob(blob)
+		if b64Err != nil {
+			return authResult{}, errNotAuthorized
+		}
+		dec, err := encoding.AESGCMDecrypt(bytes.NewReader(blobBytes), serverID)
+		if err != nil {
+			return authResult{}, errNotAuthorized
+		}
+		plain, err := io.ReadAll(dec)
+		if err != nil {
+			return authResult{}, errNotAuthorized
+		}
+		recRaw := strings.TrimSpace(string(plain))
+		if recRaw == "" {
+			return authResult{}, errNotAuthorized
+		}
+		recipient, err := age.ParseX25519Recipient(recRaw)
+		if err != nil {
+			return authResult{}, errNotAuthorized
+		}
+		return authResult{recipient: recipient, encryptedRequests: true, encryptMode: "aes"}, nil
+
+	default:
+		return authResult{}, protocolErr{code: "BAD_AUTH", message: "unsupported auth protocol: " + protocol}
 	}
-	recipient, err := age.ParseX25519Recipient(strings.TrimSpace(blob))
-	if err != nil {
-		return authResult{}, protocolErr{code: "BAD_AUTH", message: "invalid auth recipient"}
-	}
-	return authResult{recipient: recipient}, nil
 }
 
 func handleAUTHCommand(context.Context, Request, io.Writer, Deps) error {
 	return protocolErr{code: "BAD_COMMAND", message: "AUTH must be first"}
 }
 
-func decodeAUTHBlob(raw string) ([]byte, error) {
-	raw = strings.TrimSpace(raw)
-	if strings.HasPrefix(raw, "b64:") {
-		return base64.StdEncoding.DecodeString(strings.TrimPrefix(raw, "b64:"))
-	}
-	return []byte(raw), nil
+// decodeAuthBlob decodes the AUTH blob, which is base64-encoded to avoid
+// newlines in the line-oriented protocol.
+func decodeAuthBlob(raw string) ([]byte, error) {
+	return base64.StdEncoding.DecodeString(strings.TrimSpace(raw))
 }

--- a/server/internal/filexfer/ftcp/request.go
+++ b/server/internal/filexfer/ftcp/request.go
@@ -29,17 +29,35 @@ func ParseRequest(payload []byte) (Request, error) {
 	switch verb {
 	case VerbAUTH:
 		if c.eof() {
+			return Request{}, protocolErr{code: "BAD_AUTH", message: "missing auth protocol (key, age, aes)"}
+		}
+		protocol, protoErr := c.readToken()
+		if protoErr != nil {
+			return Request{}, protocolErr{code: "BAD_AUTH", message: "invalid auth protocol"}
+		}
+		switch protocol {
+		case "key":
+			if !c.eof() {
+				return Request{}, protocolErr{code: "BAD_AUTH", message: "unexpected auth arguments after key"}
+			}
+			req.Params = append(req.Params, map[string]string{"protocol": "key"})
 			return req, nil
+		case "age", "aes":
+			if c.eof() {
+				return Request{}, protocolErr{code: "BAD_AUTH", message: "missing auth blob"}
+			}
+			blob, readErr := c.readBlobValue()
+			if readErr != nil {
+				return Request{}, protocolErr{code: "BAD_AUTH", message: "invalid auth payload"}
+			}
+			if !c.eof() {
+				return Request{}, protocolErr{code: "BAD_AUTH", message: "unexpected auth arguments"}
+			}
+			req.Params = append(req.Params, map[string]string{"protocol": protocol, "blob": string(blob)})
+			return req, nil
+		default:
+			return Request{}, protocolErr{code: "BAD_AUTH", message: "unsupported auth protocol: " + protocol}
 		}
-		blob, readErr := c.readBlobValue()
-		if readErr != nil {
-			return Request{}, protocolErr{code: "BAD_AUTH", message: "invalid auth payload"}
-		}
-		if !c.eof() {
-			return Request{}, protocolErr{code: "BAD_AUTH", message: "unexpected auth arguments"}
-		}
-		req.Params = append(req.Params, map[string]string{"blob": string(blob)})
-		return req, nil
 	case VerbTXFER:
 		directory, readErr := c.readPathValue()
 		if readErr != nil {

--- a/server/internal/filexfer/ftcp/server.go
+++ b/server/internal/filexfer/ftcp/server.go
@@ -32,7 +32,6 @@ type ServerOptions struct {
 	ProgressInterval       time.Duration // tick interval for progress writes (default 1s)
 	DisableZeroCopy        bool          // force buffered send path even when zero-copy is available
 	TargetIODepth          int           // target IO depth per CPU advertised in PROBE (default 8)
-	EncryptMode            string        // "age" (default) or "aes" — selects post-AUTH stream cipher
 }
 
 type HandlerFunc func(context.Context, Request, io.Writer, Deps) error
@@ -107,7 +106,6 @@ type connSession struct {
 	syncTimeout            time.Duration
 	disableZeroCopy        bool
 	targetIODepth          int
-	encryptMode            string
 	respOut                io.Writer
 	closeResp              func() error
 	wroteBytes             bool
@@ -126,7 +124,6 @@ func handleConn(conn net.Conn, opts ServerOptions, deps Deps, onTransferCreated 
 		syncTimeout:            opts.SyncTimeout,
 		disableZeroCopy:        opts.DisableZeroCopy,
 		targetIODepth:          opts.TargetIODepth,
-		encryptMode:            opts.EncryptMode,
 		respOut:                conn,
 		closeResp:              func() error { return nil },
 		onTransferCreated:      onTransferCreated,
@@ -157,15 +154,19 @@ func (s *connSession) run() error {
 	cmdReq := firstReq
 	cmdReader := br
 	if firstReq.Verb == VerbAUTH {
-		authRes, authErr := processAUTHRequest(firstReq, s.requireAuth, s.serverID)
+		authRes, authErr := processAUTHRequest(firstReq, s.serverID)
 		if authErr != nil {
 			if errors.Is(authErr, errNotAuthorized) {
 				return protocolErr{code: "NOT_AUTHORIZED", message: "authorization failed"}
 			}
 			return authErr
 		}
+		if authRes.keyExchange {
+			// AUTH key — return the server's public key and close.
+			return writeOKLine(s.respOut, s.serverID.Recipient().String())
+		}
 		if authRes.recipient != nil {
-			switch s.encryptMode {
+			switch authRes.encryptMode {
 			case "aes":
 				encOut, encErr := encoding.AESGCMEncrypt(s.conn, authRes.recipient, 0)
 				if encErr != nil {
@@ -186,11 +187,11 @@ func (s *connSession) run() error {
 			if s.serverID == nil {
 				return protocolErr{code: "NOT_AUTHORIZED", message: "server auth key unavailable"}
 			}
-			switch s.encryptMode {
+			switch authRes.encryptMode {
 			case "aes":
-				decIn, decErr := encoding.AESGCMDecrypt(br, s.serverID, 0)
+				decIn, decErr := encoding.AESGCMDecrypt(br, s.serverID)
 				if decErr != nil {
-					return protocolErr{code: "NOT_AUTHORIZED", message: "request decryption failed: ensure client and server use the same --encrypt mode (age or aes)"}
+					return protocolErr{code: "NOT_AUTHORIZED", message: "request decryption failed"}
 				}
 				cmdReader = bufio.NewReader(decIn)
 			default:

--- a/server/main.go
+++ b/server/main.go
@@ -830,7 +830,6 @@ Options:
       --progress-path string           write transfer % to this file/pipe
       --progress-path-interval string  progress write interval (default "1s")
       --disable-zero-copy              force buffered send path (for benchmarking)
-      --encrypt string              post-AUTH stream cipher: age|aes (default "age")
 `)
 	}
 	fs.StringVar(&fileListener, "listen", fileListener, "")
@@ -846,8 +845,6 @@ Options:
 	requireAuth := fs.Bool("require-auth", false, "")
 	targetIODepth := fs.Int("target-io-depth", 8, "")
 	disableZeroCopy := fs.Bool("disable-zero-copy", false, "")
-	var encryptMode string
-	fs.StringVar(&encryptMode, "encrypt", "age", "")
 	traceFile := fs.String("trace", "", "")
 	var progressFilePath string
 	var progressIntervalRaw string
@@ -875,12 +872,6 @@ Options:
 			log.Fatalf("Failed to start trace: %v", err)
 		}
 		defer trace.Stop()
-	}
-
-	switch encryptMode {
-	case "age", "aes":
-	default:
-		log.Fatalf("Invalid --encrypt %q (supported: age, aes)", encryptMode)
 	}
 
 	if !makeDirs(keysDir) {
@@ -920,7 +911,6 @@ Options:
 		ProgressInterval:       progressInterval,
 		DisableZeroCopy:        *disableZeroCopy,
 		TargetIODepth:          *targetIODepth,
-		EncryptMode:            encryptMode,
 	}); serveErr != nil {
 		log.Fatalf("File transfer listener stopped: %v", serveErr)
 	}


### PR DESCRIPTION
Now the client auto-negotiates keys with the server, so we can encrypt both payloads and responses in a streaming fashion. Also some minor updates to our AES implementation to make it more robust to decoder/encoder changes.

There is a pretty annoying hack in here because age.Decrypt tries a final Read to see EOF, but in a duplex TCP connection we may not have anything else to send. We worked around that by half closing the connection, but that may preclude future optimizations such as pipelining multiple requests over multiple TCP connections.

We should re-visit and see if we should just switch to using our aead for everything (and just changing between poly and aes-gcm as needed).