### PR TITLE
Implement auto-detection of ideal crypto algo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
       - name: Build and test
         run: make acceptance

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 server/pinch
 server/pinch-server
+server/**/testdata
 pipetee/pipetee
 s3/
 tests/state

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image pipetee install uninstall acceptance test
+.PHONY: image pipetee install uninstall acceptance test gotest gofuzz
 
 DESTDIR ?=
 PREFIX  ?= /usr/local
@@ -7,11 +7,17 @@ image:
 	docker build -t jolynch/pinch .
 	docker build -t jolynch/pinch-server server
 
-acceptance: image test
+acceptance: image test gotest gofuzz
 
 test:
 	tests/test_tools.sh
 	tests/test_server.sh
+
+gotest:
+	$(MAKE) -C server test
+
+gofuzz:
+	$(MAKE) -C server fuzz
 
 pipetee:
 	gcc pipetee/pipetee.c -o pipetee/pipetee

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,0 +1,17 @@
+.PHONY: all build test fuzz
+
+FUZZTIME ?= 5s
+
+all: build test fuzz
+
+build:
+	CGO_ENABLED=0 go build -a -tags netgo -ldflags='-s -w -extldflags "-static"' -o pinch-server
+
+test: build
+	go test ./...
+
+fuzz:
+	go test ./internal/filexfer/encoding -run=^$$ -fuzz=FuzzRoundTrip -fuzztime=$(FUZZTIME)
+	go test ./internal/filexfer/ftcp     -run=^$$ -fuzz=FuzzSync      -fuzztime=$(FUZZTIME)
+	go test ./utils                      -run=^$$ -fuzz=FuzzCommonPrefixLen -fuzztime=$(FUZZTIME)
+	go test ./filexfer                   -run=^$$ -fuzz=FuzzSuggestBatchMaxBytes -fuzztime=$(FUZZTIME)

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -1681,7 +1681,7 @@ func SuggestBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windo
 	// that lone stream into smaller batches only adds coordination overhead
 	// without creating additional across-file concurrency.
 	if windowConcurrency == 1 {
-		return windowBytes
+		return largestPow2MiBWithin(windowBytes)
 	}
 	if windowConcurrency <= 0 {
 		windowConcurrency = 4
@@ -1714,11 +1714,33 @@ func SuggestBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windo
 	// Floor: a batch is one TCP SEND, so it should not be smaller than the
 	// socket buffer the OS allocated — sending less wastes a round-trip for
 	// data that would have fit in a single write/read cycle.
-	floor := max(serverWmemBytes, int64(utils.MaxSocketReadBufferBytes()))
-	batch = max(batch, floor)
+	// Round the floor up to the nearest power-of-2 MiB so the result stays aligned.
+	rawFloor := max(serverWmemBytes, int64(utils.MaxSocketReadBufferBytes()))
+	floorMiB := max(int64(1), (rawFloor+mib-1)/mib)
+	floorPow2 := int64(1)
+	for floorPow2 < floorMiB {
+		floorPow2 <<= 1
+	}
+	batch = max(batch, floorPow2*mib)
 
 	// Ceiling: a batch larger than the transfer window is meaningless.
-	return min(batch, windowBytes)
+	// Round down to keep MiB alignment.
+	return min(batch, largestPow2MiBWithin(windowBytes))
+}
+
+// largestPow2MiBWithin returns the largest power-of-2 multiple of MiB that is
+// <= v. If v < 1 MiB it returns v unchanged (sub-MiB callers handle their own
+// alignment).
+func largestPow2MiBWithin(v int64) int64 {
+	const mib = int64(1 << 20)
+	if v < mib {
+		return v
+	}
+	p := int64(1)
+	for p*2 <= v/mib {
+		p <<= 1
+	}
+	return p * mib
 }
 
 func suggestedConcurrencyFromProbe(serverCPU int, ioDepth int, strategy string) int {

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -2854,7 +2854,7 @@ func decodePayloadReader(payload io.Reader, comp string, enc string, identity ag
 		if identity == nil {
 			return nil, errors.New("missing identity for AES encrypted frame")
 		}
-		decrypted, err := intencoding.AESGCMDecrypt(payload, identity)
+		decrypted, err := intencoding.Decrypt(payload, identity)
 		if err != nil {
 			return nil, err
 		}

--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -1677,6 +1677,12 @@ func SuggestBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windo
 	if windowBytes <= 0 {
 		return defaultClientBatchMaxBytes
 	}
+	// A single concurrent window should use the full transfer window. Splitting
+	// that lone stream into smaller batches only adds coordination overhead
+	// without creating additional across-file concurrency.
+	if windowConcurrency == 1 {
+		return windowBytes
+	}
 	if windowConcurrency <= 0 {
 		windowConcurrency = 4
 	}

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -246,7 +246,7 @@ func (c *Client) sendTCPAuth(conn net.Conn, state tcpAuthState) error {
 	defer c.releaseScratchBuffer(encrypted)
 	switch state.encMode {
 	case "aes":
-		ew, encErr := intencoding.AESGCMEncrypt(encrypted, recipient, 0)
+		ew, encErr := intencoding.Encrypt(encrypted, recipient, intencoding.Options{Algorithm: intencoding.AlgorithmAES})
 		if encErr != nil {
 			return encErr
 		}
@@ -297,7 +297,7 @@ func (c *Client) sendTCPCommand(conn net.Conn, state tcpAuthState, payload strin
 	var ew io.WriteCloser
 	switch state.encMode {
 	case "aes":
-		ew, err = intencoding.AESGCMEncrypt(conn, recipient, 0)
+		ew, err = intencoding.Encrypt(conn, recipient, intencoding.Options{Algorithm: intencoding.AlgorithmAES})
 	default:
 		ew, err = age.Encrypt(conn, recipient)
 	}
@@ -325,7 +325,7 @@ func (c *Client) responseReaderForTCP(conn net.Conn, state tcpAuthState) (io.Rea
 	}
 	switch state.encMode {
 	case "aes":
-		decReader, err := intencoding.AESGCMDecrypt(conn, identity)
+		decReader, err := intencoding.Decrypt(conn, identity)
 		if err != nil {
 			return nil, fmt.Errorf("aes decryption failed: %w", err)
 		}
@@ -755,7 +755,7 @@ func (c *Client) sendTCPProbe(conn net.Conn, state tcpAuthState, cmd string, pro
 	var ew io.WriteCloser
 	switch state.encMode {
 	case "aes":
-		ew, err = intencoding.AESGCMEncrypt(conn, recipient, 0)
+		ew, err = intencoding.Encrypt(conn, recipient, intencoding.Options{Algorithm: intencoding.AlgorithmAES})
 	default:
 		ew, err = age.Encrypt(conn, recipient)
 	}

--- a/server/internal/cmd/filexfercli/cli_test.go
+++ b/server/internal/cmd/filexfercli/cli_test.go
@@ -115,7 +115,7 @@ func serveFTCPConn(conn net.Conn, serverID *age.X25519Identity, handler func(int
 		var plain []byte
 		switch protocol {
 		case "aes":
-			dec, decErr := encoding.AESGCMDecrypt(bytes.NewReader(blobBytes), serverID)
+			dec, decErr := encoding.Decrypt(bytes.NewReader(blobBytes), serverID)
 			if decErr != nil {
 				_, _ = io.WriteString(conn, "ERR NOT_AUTHORIZED\r\n")
 				return
@@ -144,7 +144,7 @@ func serveFTCPConn(conn net.Conn, serverID *age.X25519Identity, handler func(int
 		var encErr error
 		switch protocol {
 		case "aes":
-			ew, encErr = encoding.AESGCMEncrypt(conn, recipient, 0)
+			ew, encErr = encoding.Encrypt(conn, recipient, encoding.Options{Algorithm: encoding.AlgorithmAES})
 		default:
 			ew, encErr = age.Encrypt(conn, recipient)
 		}
@@ -158,7 +158,7 @@ func serveFTCPConn(conn net.Conn, serverID *age.X25519Identity, handler func(int
 		var cmdReader io.Reader
 		switch protocol {
 		case "aes":
-			cmdReader, err = encoding.AESGCMDecrypt(br, serverID)
+			cmdReader, err = encoding.Decrypt(br, serverID)
 		default:
 			cmdReader, err = age.Decrypt(br, serverID)
 		}

--- a/server/internal/filexfer/encoding/aead.go
+++ b/server/internal/filexfer/encoding/aead.go
@@ -9,10 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 
 	"filippo.io/age"
+	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/hkdf"
+	"golang.org/x/sys/cpu"
 )
 
 const (
@@ -22,29 +25,75 @@ const (
 	aeadFileKeySize  = 16
 	aeadDefaultChunk = 64 * 1024
 	aeadMinChunkSize = 1024
-	aeadHKDFInfo     = "pinch-aes-gcm-v1"
 	aeadVersion      = 0x01
 )
+
+type Algorithm string
+
+const (
+	AlgorithmAES      Algorithm = "aes"
+	AlgorithmChaCha20 Algorithm = "chacha20"
+)
+
+type Options struct {
+	ChunkSize int
+	Algorithm Algorithm
+}
+
+func (o Options) ResolveAlgorithm() (Algorithm, error) {
+	if o.Algorithm == "" {
+		return RecommendedCipher(), nil
+	}
+	return validateAlgorithm(o.Algorithm)
+}
+
+func (o Options) ResolveChunkSize() int {
+	if o.ChunkSize <= 0 {
+		return aeadDefaultChunk
+	}
+	if o.ChunkSize < aeadMinChunkSize {
+		return aeadMinChunkSize
+	}
+	return o.ChunkSize
+}
+
+func (o Options) HKDFInfo() (string, error) {
+	algorithm, err := o.ResolveAlgorithm()
+	if err != nil {
+		return "", err
+	}
+
+	algorithmName, err := hkdfAlgorithmName(algorithm)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("pinch-%s-v%d", algorithmName, aeadVersion), nil
+}
 
 const aeadMaxAADChunkCount = ^uint64(0) >> 1
 
 var aeadBufferPools sync.Map // map[int]*sync.Pool
 
-// AESGCMEncrypt creates a streaming AES-GCM encrypted writer. It performs
-// X25519 key exchange via the recipient's Wrap method (compatible with
-// age.X25519Recipient), writes a binary key-exchange header to dst, then
-// returns a WriteCloser that encrypts data in fixed-size chunks.
+// Encrypt creates a streaming AEAD encrypted writer. It performs X25519 key
+// exchange via the recipient's Wrap method (compatible with age.X25519Recipient),
+// writes a binary key-exchange header to dst, then returns a WriteCloser that
+// encrypts data in fixed-size chunks.
 //
-// chunkSize is the plaintext chunk size in bytes. A non-positive value uses the
-// default size. Values smaller than 1 KiB are clamped upward.
+// A zero ChunkSize uses the default. Values smaller than 1 KiB are clamped
+// upward. A zero Algorithm uses RecommendedCipher.
 //
 // The caller must call Close to flush the final chunk. Not goroutine-safe.
-func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.WriteCloser, error) {
+func Encrypt(dst io.Writer, recipient age.Recipient, opts Options) (io.WriteCloser, error) {
 	if dst == nil {
 		return nil, errors.New("nil destination writer")
 	}
 	if recipient == nil {
 		return nil, errors.New("nil recipient")
+	}
+
+	algorithm, err := opts.ResolveAlgorithm()
+	if err != nil {
+		return nil, err
 	}
 
 	fileKey := make([]byte, aeadFileKeySize)
@@ -60,13 +109,12 @@ func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.Wr
 		return nil, fmt.Errorf("expected 1 stanza from Wrap, got %d", len(stanzas))
 	}
 
-	chunkSize = normalizeAEADChunkSize(chunkSize)
-
-	if err := writeStanzaHeader(dst, stanzas[0], chunkSize); err != nil {
+	chunkSize := opts.ResolveChunkSize()
+	if err := writeStanzaHeader(dst, algorithm, stanzas[0], chunkSize); err != nil {
 		return nil, fmt.Errorf("write stanza header: %w", err)
 	}
 
-	gcm, err := newGCM(fileKey)
+	aeadCipher, err := newAEAD(fileKey, algorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -74,8 +122,8 @@ func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.Wr
 	buf, chunkSize, release := acquireAEADBuffer(chunkSize)
 	half := len(buf) / 2
 
-	return &aesgcmWriter{
-		gcm:        gcm,
+	return &aeadWriter{
+		aead:       aeadCipher,
 		dst:        dst,
 		plainBuf:   buf[:half],
 		sealBuf:    buf[half:],
@@ -85,13 +133,13 @@ func AESGCMEncrypt(dst io.Writer, recipient age.Recipient, chunkSize int) (io.Wr
 	}, nil
 }
 
-// AESGCMDecrypt creates a streaming AES-GCM decrypting reader. It reads
-// the key-exchange header from src, recovers the file key via the identity's
-// Unwrap method (compatible with age.X25519Identity), then returns a Reader
-// that decrypts chunks on the fly.
+// Decrypt creates a streaming AEAD decrypting reader. It reads the key-exchange
+// header from src, recovers the file key via the identity's Unwrap method
+// (compatible with age.X25519Identity), then returns a Reader that decrypts
+// chunks on the fly.
 //
 // Not goroutine-safe.
-func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
+func Decrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 	if src == nil {
 		return nil, errors.New("nil source reader")
 	}
@@ -99,7 +147,7 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 		return nil, errors.New("nil identity")
 	}
 
-	stanza, chunkSize, err := readStanzaHeader(src)
+	algorithm, stanza, chunkSize, err := readStanzaHeader(src)
 	if err != nil {
 		return nil, fmt.Errorf("read stanza header: %w", err)
 	}
@@ -109,7 +157,7 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 		return nil, fmt.Errorf("unwrap file key: %w", err)
 	}
 
-	gcm, err := newGCM(fileKey)
+	aeadCipher, err := newAEAD(fileKey, algorithm)
 	if err != nil {
 		return nil, err
 	}
@@ -117,8 +165,8 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 	buf, chunkSize, release := acquireAEADBuffer(chunkSize)
 	half := len(buf) / 2
 
-	return &aesgcmReader{
-		gcm:        gcm,
+	return &aeadReader{
+		aead:       aeadCipher,
 		src:        src,
 		cipherBuf:  buf[:half],
 		plainBuf:   buf[half:],
@@ -128,23 +176,120 @@ func AESGCMDecrypt(src io.Reader, identity age.Identity) (io.Reader, error) {
 	}, nil
 }
 
-// newGCM derives an AES-256 key from the age file key via HKDF-SHA256 and
-// returns a GCM cipher instance.
-func newGCM(fileKey []byte) (cipher.AEAD, error) {
-	hk := hkdf.New(sha256.New, fileKey, nil, []byte(aeadHKDFInfo))
-	aesKey := make([]byte, aeadKeySize)
-	if _, err := io.ReadFull(hk, aesKey); err != nil {
-		return nil, fmt.Errorf("derive AES key: %w", err)
+func RecommendedCipher() Algorithm {
+	switch runtime.GOARCH {
+	case "386", "amd64":
+		if cpu.X86.HasAES {
+			return AlgorithmAES
+		}
+	case "arm":
+		if cpu.ARM.HasAES {
+			return AlgorithmAES
+		}
+	case "arm64":
+		if cpu.ARM64.HasAES {
+			return AlgorithmAES
+		}
+	case "s390x":
+		if cpu.S390X.HasAES {
+			return AlgorithmAES
+		}
 	}
-	block, err := aes.NewCipher(aesKey)
+	return AlgorithmChaCha20
+}
+
+func validateAlgorithm(algorithm Algorithm) (Algorithm, error) {
+	switch algorithm {
+	case AlgorithmAES, AlgorithmChaCha20:
+		return algorithm, nil
+	default:
+		return "", fmt.Errorf("unsupported AEAD algorithm: %q", algorithm)
+	}
+}
+
+func newAEAD(fileKey []byte, algorithm Algorithm) (cipher.AEAD, error) {
+	key, err := deriveAEADKey(fileKey, algorithm)
 	if err != nil {
 		return nil, err
 	}
-	return cipher.NewGCM(block)
+
+	switch algorithm {
+	case AlgorithmAES:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		return cipher.NewGCM(block)
+	case AlgorithmChaCha20:
+		return chacha20poly1305.New(key)
+	default:
+		return nil, fmt.Errorf("unsupported AEAD algorithm: %q", algorithm)
+	}
+}
+
+func deriveAEADKey(fileKey []byte, algorithm Algorithm) ([]byte, error) {
+	info, err := Options{Algorithm: algorithm}.HKDFInfo()
+	if err != nil {
+		return nil, err
+	}
+	deriveName, err := cipherName(algorithm)
+	if err != nil {
+		return nil, err
+	}
+	hk := hkdf.New(sha256.New, fileKey, nil, []byte(info))
+	key := make([]byte, aeadKeySize)
+	if _, err := io.ReadFull(hk, key); err != nil {
+		return nil, fmt.Errorf("derive %s key: %w", deriveName, err)
+	}
+	return key, nil
+}
+
+func hkdfAlgorithmName(algorithm Algorithm) (string, error) {
+	switch algorithm {
+	case AlgorithmAES:
+		return "aes-gcm", nil
+	case AlgorithmChaCha20:
+		return "chacha20-poly1305", nil
+	default:
+		return "", fmt.Errorf("unsupported AEAD algorithm: %q", algorithm)
+	}
+}
+
+func cipherName(algorithm Algorithm) (string, error) {
+	switch algorithm {
+	case AlgorithmAES:
+		return "AES", nil
+	case AlgorithmChaCha20:
+		return "ChaCha20-Poly1305", nil
+	default:
+		return "", fmt.Errorf("unsupported AEAD algorithm: %q", algorithm)
+	}
+}
+
+func algorithmID(algorithm Algorithm) (byte, error) {
+	switch algorithm {
+	case AlgorithmAES:
+		return 0x01, nil
+	case AlgorithmChaCha20:
+		return 0x02, nil
+	default:
+		return 0, fmt.Errorf("unsupported AEAD algorithm: %q", algorithm)
+	}
+}
+
+func parseAlgorithmID(id byte) (Algorithm, error) {
+	switch id {
+	case 0x01:
+		return AlgorithmAES, nil
+	case 0x02:
+		return AlgorithmChaCha20, nil
+	default:
+		return "", fmt.Errorf("unsupported AEAD algorithm id: %d", id)
+	}
 }
 
 func acquireAEADBuffer(chunkSize int) ([]byte, int, func()) {
-	chunkSize = normalizeAEADChunkSize(chunkSize)
+	chunkSize = Options{ChunkSize: chunkSize}.ResolveChunkSize()
 	bufSize := 2 * (chunkSize + aeadTagSize)
 	pool := aeadBufferPool(bufSize)
 	raw := pool.Get()
@@ -173,16 +318,6 @@ func writeFull(w io.Writer, p []byte) error {
 	return nil
 }
 
-func normalizeAEADChunkSize(chunkSize int) int {
-	if chunkSize <= 0 {
-		return aeadDefaultChunk
-	}
-	if chunkSize < aeadMinChunkSize {
-		return aeadMinChunkSize
-	}
-	return chunkSize
-}
-
 func aeadBufferPool(size int) *sync.Pool {
 	if existing, ok := aeadBufferPools.Load(size); ok {
 		return existing.(*sync.Pool)
@@ -201,14 +336,19 @@ func aeadBufferPool(size int) *sync.Pool {
 //
 // Format:
 //   [1 byte: version=0x01]
+//   [1 byte: algorithm]
 //   [2 bytes BE: type_len][type_len bytes: Stanza.Type]
 //   [2 bytes BE: num_args]
 //     per arg: [2 bytes BE: arg_len][arg_len bytes: arg]
 //   [2 bytes BE: body_len][body_len bytes: Stanza.Body]
 //   [4 bytes BE: chunk_size]
 
-func writeStanzaHeader(w io.Writer, s *age.Stanza, chunkSize int) error {
-	if err := writeFull(w, []byte{aeadVersion}); err != nil {
+func writeStanzaHeader(w io.Writer, algorithm Algorithm, s *age.Stanza, chunkSize int) error {
+	id, err := algorithmID(algorithm)
+	if err != nil {
+		return err
+	}
+	if err := writeFull(w, []byte{aeadVersion, id}); err != nil {
 		return err
 	}
 	if err := writeU16Prefixed(w, []byte(s.Type)); err != nil {
@@ -232,52 +372,56 @@ func writeStanzaHeader(w io.Writer, s *age.Stanza, chunkSize int) error {
 	return writeFull(w, chunkSizeBuf[:])
 }
 
-func readStanzaHeader(r io.Reader) (*age.Stanza, int, error) {
-	var ver [1]byte
-	if _, err := io.ReadFull(r, ver[:]); err != nil {
-		return nil, 0, fmt.Errorf("read version: %w", err)
+func readStanzaHeader(r io.Reader) (Algorithm, *age.Stanza, int, error) {
+	var header [2]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return "", nil, 0, fmt.Errorf("read header: %w", err)
 	}
-	if ver[0] != aeadVersion {
-		return nil, 0, fmt.Errorf("unsupported AEAD version: %d", ver[0])
+	if header[0] != aeadVersion {
+		return "", nil, 0, fmt.Errorf("unsupported AEAD version: %d", header[0])
+	}
+	algorithm, err := parseAlgorithmID(header[1])
+	if err != nil {
+		return "", nil, 0, err
 	}
 
 	typ, err := readU16Prefixed(r)
 	if err != nil {
-		return nil, 0, fmt.Errorf("read stanza type: %w", err)
+		return "", nil, 0, fmt.Errorf("read stanza type: %w", err)
 	}
 	if string(typ) != "X25519" {
-		return nil, 0, fmt.Errorf("unsupported stanza type: %q", string(typ))
+		return "", nil, 0, fmt.Errorf("unsupported stanza type: %q", string(typ))
 	}
 
 	var numArgsBuf [2]byte
 	if _, err := io.ReadFull(r, numArgsBuf[:]); err != nil {
-		return nil, 0, fmt.Errorf("read num_args: %w", err)
+		return "", nil, 0, fmt.Errorf("read num_args: %w", err)
 	}
 	numArgs := int(binary.BigEndian.Uint16(numArgsBuf[:]))
 	args := make([]string, numArgs)
 	for i := range args {
 		a, err := readU16Prefixed(r)
 		if err != nil {
-			return nil, 0, fmt.Errorf("read arg %d: %w", i, err)
+			return "", nil, 0, fmt.Errorf("read arg %d: %w", i, err)
 		}
 		args[i] = string(a)
 	}
 
 	body, err := readU16Prefixed(r)
 	if err != nil {
-		return nil, 0, fmt.Errorf("read body: %w", err)
+		return "", nil, 0, fmt.Errorf("read body: %w", err)
 	}
 
 	var chunkSizeBuf [4]byte
 	if _, err := io.ReadFull(r, chunkSizeBuf[:]); err != nil {
-		return nil, 0, fmt.Errorf("read chunk size: %w", err)
+		return "", nil, 0, fmt.Errorf("read chunk size: %w", err)
 	}
 	chunkSize := int(binary.BigEndian.Uint32(chunkSizeBuf[:]))
 	if chunkSize < aeadMinChunkSize {
-		return nil, 0, fmt.Errorf("invalid AEAD chunk size: %d", chunkSize)
+		return "", nil, 0, fmt.Errorf("invalid AEAD chunk size: %d", chunkSize)
 	}
 
-	return &age.Stanza{Type: string(typ), Args: args, Body: body}, chunkSize, nil
+	return algorithm, &age.Stanza{Type: string(typ), Args: args, Body: body}, chunkSize, nil
 }
 
 func writeU16Prefixed(w io.Writer, data []byte) error {
@@ -310,16 +454,16 @@ func readU16Prefixed(r io.Reader) ([]byte, error) {
 }
 
 // ---------------------------------------------------------------------------
-// aesgcmWriter — streaming AEAD encrypt
+// aeadWriter — streaming AEAD encrypt
 // ---------------------------------------------------------------------------
 //
 // Nonce layout (12 bytes):
-//   bytes 0–2:  zero (high bits of chunk count, never reached in practice)
-//   bytes 3–10: big-endian uint64 chunk count
+//   bytes 0-2:  zero (high bits of chunk count, never reached in practice)
+//   bytes 3-10: big-endian uint64 chunk count
 //   byte 11:    0x00 = non-final chunk, 0x01 = final chunk
 
-type aesgcmWriter struct {
-	gcm        cipher.AEAD
+type aeadWriter struct {
+	aead       cipher.AEAD
 	dst        io.Writer
 	plainBuf   []byte // first half of caller buffer — plaintext accumulation
 	sealBuf    []byte // second half of caller buffer — Seal output
@@ -333,7 +477,7 @@ type aesgcmWriter struct {
 	closed     bool
 }
 
-func (w *aesgcmWriter) Write(p []byte) (int, error) {
+func (w *aeadWriter) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, errors.New("write to closed AEAD writer")
 	}
@@ -359,7 +503,7 @@ func (w *aesgcmWriter) Write(p []byte) (int, error) {
 	return total, nil
 }
 
-func (w *aesgcmWriter) Close() error {
+func (w *aeadWriter) Close() error {
 	if w.closed {
 		return nil
 	}
@@ -371,13 +515,13 @@ func (w *aesgcmWriter) Close() error {
 	return w.flushChunk(true)
 }
 
-func (w *aesgcmWriter) flushChunk(last bool) error {
+func (w *aeadWriter) flushChunk(last bool) error {
 	w.buildNonce(last)
 	aad, err := buildChunkAAD(w.chunkSize, w.chunkCount, last)
 	if err != nil {
 		return err
 	}
-	sealed := w.gcm.Seal(w.sealBuf[:0], w.nonce[:], w.plainBuf[:w.plainN], aad[:])
+	sealed := w.aead.Seal(w.sealBuf[:0], w.nonce[:], w.plainBuf[:w.plainN], aad[:])
 	if err := writeFull(w.dst, sealed); err != nil {
 		return err
 	}
@@ -386,7 +530,7 @@ func (w *aesgcmWriter) flushChunk(last bool) error {
 	return nil
 }
 
-func (w *aesgcmWriter) buildNonce(last bool) {
+func (w *aeadWriter) buildNonce(last bool) {
 	binary.BigEndian.PutUint64(w.nonce[3:11], w.chunkCount)
 	if last {
 		w.nonce[11] = 0x01
@@ -395,7 +539,7 @@ func (w *aesgcmWriter) buildNonce(last bool) {
 	}
 }
 
-func (w *aesgcmWriter) release() {
+func (w *aeadWriter) release() {
 	if w.releaseBuf == nil {
 		return
 	}
@@ -407,11 +551,11 @@ func (w *aesgcmWriter) release() {
 }
 
 // ---------------------------------------------------------------------------
-// aesgcmReader — streaming AEAD decrypt
+// aeadReader — streaming AEAD decrypt
 // ---------------------------------------------------------------------------
 
-type aesgcmReader struct {
-	gcm        cipher.AEAD
+type aeadReader struct {
+	aead       cipher.AEAD
 	src        io.Reader
 	cipherBuf  []byte // first half of caller buffer — ReadFull target
 	plainBuf   []byte // second half of caller buffer — Open output
@@ -425,7 +569,7 @@ type aesgcmReader struct {
 	done       bool
 }
 
-func (r *aesgcmReader) Read(p []byte) (int, error) {
+func (r *aeadReader) Read(p []byte) (int, error) {
 	if len(r.unread) > 0 {
 		n := copy(p, r.unread)
 		r.unread = r.unread[n:]
@@ -456,7 +600,7 @@ func (r *aesgcmReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-func (r *aesgcmReader) readChunk() error {
+func (r *aeadReader) readChunk() error {
 	sealedSize := r.chunkSize + aeadTagSize
 	n, err := io.ReadFull(r.src, r.cipherBuf[:sealedSize])
 
@@ -468,7 +612,7 @@ func (r *aesgcmReader) readChunk() error {
 		if aadErr != nil {
 			return aadErr
 		}
-		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
+		plaintext, openErr := r.aead.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr == nil {
 			r.unread = plaintext
 			r.chunkCount++
@@ -481,7 +625,7 @@ func (r *aesgcmReader) readChunk() error {
 		if aadErr != nil {
 			return aadErr
 		}
-		plaintext, openErr = r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
+		plaintext, openErr = r.aead.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr != nil {
 			return fmt.Errorf("AEAD authentication failed: %w", openErr)
 		}
@@ -497,7 +641,7 @@ func (r *aesgcmReader) readChunk() error {
 		if aadErr != nil {
 			return aadErr
 		}
-		plaintext, openErr := r.gcm.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
+		plaintext, openErr := r.aead.Open(r.plainBuf[:0], r.nonce[:], r.cipherBuf[:n], aad[:])
 		if openErr != nil {
 			return fmt.Errorf("AEAD authentication failed on final chunk: %w", openErr)
 		}
@@ -515,7 +659,7 @@ func (r *aesgcmReader) readChunk() error {
 	}
 }
 
-func (r *aesgcmReader) buildNonce(last bool) {
+func (r *aeadReader) buildNonce(last bool) {
 	binary.BigEndian.PutUint64(r.nonce[3:11], r.chunkCount)
 	if last {
 		r.nonce[11] = 0x01
@@ -524,7 +668,7 @@ func (r *aesgcmReader) buildNonce(last bool) {
 	}
 }
 
-func (r *aesgcmReader) release() {
+func (r *aeadReader) release() {
 	if r.releaseBuf == nil {
 		return
 	}

--- a/server/internal/filexfer/encoding/aead_test.go
+++ b/server/internal/filexfer/encoding/aead_test.go
@@ -5,10 +5,13 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"io"
+	"strconv"
 	"testing"
 
 	"filippo.io/age"
 )
+
+var testAlgorithms = []Algorithm{AlgorithmAES, AlgorithmChaCha20}
 
 func generateTestIdentity(t testing.TB) (*age.X25519Identity, *age.X25519Recipient) {
 	t.Helper()
@@ -19,12 +22,12 @@ func generateTestIdentity(t testing.TB) (*age.X25519Identity, *age.X25519Recipie
 	return id, id.Recipient()
 }
 
-func roundTrip(t testing.TB, plaintext []byte, chunkSize int) {
+func roundTrip(t testing.TB, algorithm Algorithm, plaintext []byte, chunkSize int) {
 	t.Helper()
 	id, recipient := generateTestIdentity(t)
 
 	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, chunkSize)
+	w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: algorithm, ChunkSize: chunkSize})
 	if err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
@@ -35,7 +38,7 @@ func roundTrip(t testing.TB, plaintext []byte, chunkSize int) {
 		t.Fatalf("close: %v", err)
 	}
 
-	r, err := AESGCMDecrypt(&ciphertext, id)
+	r, err := Decrypt(&ciphertext, id)
 	if err != nil {
 		t.Fatalf("decrypt: %v", err)
 	}
@@ -48,125 +51,205 @@ func roundTrip(t testing.TB, plaintext []byte, chunkSize int) {
 	}
 }
 
-func FuzzAESGCMRoundTrip(f *testing.F) {
-	// Seed corpus with interesting sizes.
-	for _, size := range []int{0, 1, 16, 1023, 1024, 65535, 65536, 65537, 128*1024 - 1, 128 * 1024, 128*1024 + 1} {
-		data := make([]byte, size)
-		if size > 0 {
-			rand.Read(data)
+func FuzzRoundTrip(f *testing.F) {
+	sizes := []int{0, 1, 16, 1023, 1024, 4096, 65535, 65536, 65537, 128*1024 - 1, 128 * 1024, 128*1024 + 1}
+	chunkSizes := []int{0, 512, 1024, 4096, 64 * 1024}
+	for _, algorithm := range testAlgorithms {
+		for _, chunkSize := range chunkSizes {
+			for _, size := range sizes {
+				data := make([]byte, size)
+				if size > 0 {
+					rand.Read(data)
+				}
+				f.Add(string(algorithm), chunkSize, data)
+			}
 		}
-		f.Add(data)
 	}
 
-	f.Fuzz(func(t *testing.T, data []byte) {
-		roundTrip(t, data, 0)
+	f.Fuzz(func(t *testing.T, rawAlg string, chunkSize int, data []byte) {
+		algorithm := Algorithm(rawAlg)
+		switch algorithm {
+		case AlgorithmAES, AlgorithmChaCha20:
+		default:
+			algorithm = AlgorithmAES
+		}
+		roundTrip(t, algorithm, data, chunkSize)
 	})
 }
 
-func TestAESGCMRoundTripLarge(t *testing.T) {
-	// Explicit large sizes beyond typical fuzz corpus.
-	for _, size := range []int{4 * 1024 * 1024, 4*1024*1024 + 1} {
-		data := make([]byte, size)
-		rand.Read(data)
-		roundTrip(t, data, 0)
+func TestRoundTripLarge(t *testing.T) {
+	for _, algorithm := range testAlgorithms {
+		for _, size := range []int{4 * 1024 * 1024, 4*1024*1024 + 1} {
+			data := make([]byte, size)
+			rand.Read(data)
+			t.Run(algorithmName(algorithm)+"/"+strconv.Itoa(size), func(t *testing.T) {
+				roundTrip(t, algorithm, data, 0)
+			})
+		}
 	}
 }
 
-func TestAESGCMSmallChunkSize(t *testing.T) {
+func TestSmallChunkSize(t *testing.T) {
 	data := make([]byte, 100*1024)
 	rand.Read(data)
-	roundTrip(t, data, 512)
-}
-
-func TestAESGCMTampered(t *testing.T) {
-	id, recipient := generateTestIdentity(t)
-
-	plaintext := []byte("hello world, this is a test of tamper detection")
-	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, 0)
-	if err != nil {
-		t.Fatalf("encrypt: %v", err)
-	}
-	w.Write(plaintext)
-	w.Close()
-
-	// Flip a bit in the ciphertext payload (after the stanza header).
-	raw := ciphertext.Bytes()
-	if len(raw) < 100 {
-		t.Fatal("ciphertext too short")
-	}
-	raw[len(raw)-10] ^= 0x01
-
-	r, err := AESGCMDecrypt(bytes.NewReader(raw), id)
-	if err != nil {
-		t.Fatalf("decrypt init: %v", err)
-	}
-	if _, err := io.ReadAll(r); err == nil {
-		t.Fatal("expected authentication error for tampered ciphertext")
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			roundTrip(t, algorithm, data, 512)
+		})
 	}
 }
 
-func TestAESGCMWrongKey(t *testing.T) {
-	_, recipient := generateTestIdentity(t)
-	wrongID, _ := generateTestIdentity(t)
+func TestTamperedCiphertext(t *testing.T) {
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			id, recipient := generateTestIdentity(t)
 
-	plaintext := []byte("secret message")
-	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, 0)
-	if err != nil {
-		t.Fatalf("encrypt: %v", err)
-	}
-	w.Write(plaintext)
-	w.Close()
+			plaintext := []byte("hello world, this is a test of tamper detection")
+			var ciphertext bytes.Buffer
+			w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: algorithm})
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			if _, err := w.Write(plaintext); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
 
-	_, err = AESGCMDecrypt(&ciphertext, wrongID)
-	if err == nil {
-		t.Fatal("expected error decrypting with wrong identity")
-	}
-}
+			raw := ciphertext.Bytes()
+			if len(raw) < 100 {
+				t.Fatal("ciphertext too short")
+			}
+			raw[len(raw)-10] ^= 0x01
 
-func TestAESGCMTruncated(t *testing.T) {
-	id, recipient := generateTestIdentity(t)
-
-	plaintext := make([]byte, 200*1024)
-	rand.Read(plaintext)
-
-	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, 0)
-	if err != nil {
-		t.Fatalf("encrypt: %v", err)
-	}
-	w.Write(plaintext)
-	w.Close()
-
-	// Truncate to half the ciphertext.
-	truncated := ciphertext.Bytes()[:ciphertext.Len()/2]
-	r, err := AESGCMDecrypt(bytes.NewReader(truncated), id)
-	if err != nil {
-		t.Fatalf("decrypt init: %v", err)
-	}
-	if _, err := io.ReadAll(r); err == nil {
-		t.Fatal("expected error reading truncated ciphertext")
+			r, err := Decrypt(bytes.NewReader(raw), id)
+			if err != nil {
+				t.Fatalf("decrypt init: %v", err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected authentication error for tampered ciphertext")
+			}
+		})
 	}
 }
 
-func TestAESGCMDefaultChunkSize(t *testing.T) {
+func TestWrongKey(t *testing.T) {
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			_, recipient := generateTestIdentity(t)
+			wrongID, _ := generateTestIdentity(t)
+
+			plaintext := []byte("secret message")
+			var ciphertext bytes.Buffer
+			w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: algorithm})
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			if _, err := w.Write(plaintext); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			_, err = Decrypt(&ciphertext, wrongID)
+			if err == nil {
+				t.Fatal("expected error decrypting with wrong identity")
+			}
+		})
+	}
+}
+
+func TestTruncatedCiphertext(t *testing.T) {
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			id, recipient := generateTestIdentity(t)
+
+			plaintext := make([]byte, 200*1024)
+			rand.Read(plaintext)
+
+			var ciphertext bytes.Buffer
+			w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: algorithm})
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			if _, err := w.Write(plaintext); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			truncated := ciphertext.Bytes()[:ciphertext.Len()/2]
+			r, err := Decrypt(bytes.NewReader(truncated), id)
+			if err != nil {
+				t.Fatalf("decrypt init: %v", err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected error reading truncated ciphertext")
+			}
+		})
+	}
+}
+
+func TestDefaultChunkSize(t *testing.T) {
 	data := make([]byte, 100*1024)
 	rand.Read(data)
-	roundTrip(t, data, 0)
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			roundTrip(t, algorithm, data, 0)
+		})
+	}
 }
 
-func TestAESGCMChunkSizeFromHeader(t *testing.T) {
+func TestChunkSizeFromHeader(t *testing.T) {
 	data := make([]byte, 100*1024)
 	rand.Read(data)
-	roundTrip(t, data, 4*1024)
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			roundTrip(t, algorithm, data, 4*1024)
+		})
+	}
 }
 
-func TestAESGCMHeaderChunkSizeTamper(t *testing.T) {
+func TestHeaderChunkSizeTamper(t *testing.T) {
+	for _, algorithm := range testAlgorithms {
+		t.Run(algorithmName(algorithm), func(t *testing.T) {
+			id, recipient := generateTestIdentity(t)
+
+			var ciphertext bytes.Buffer
+			w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: algorithm, ChunkSize: 4 * 1024})
+			if err != nil {
+				t.Fatalf("encrypt: %v", err)
+			}
+			if _, err := w.Write([]byte("tamper me")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			raw := ciphertext.Bytes()
+			offset := stanzaChunkSizeOffset(t, raw)
+			binary.BigEndian.PutUint32(raw[offset:offset+4], 8*1024)
+
+			r, err := Decrypt(bytes.NewReader(raw), id)
+			if err != nil {
+				t.Fatalf("decrypt init: %v", err)
+			}
+			if _, err := io.ReadAll(r); err == nil {
+				t.Fatal("expected authentication error for tampered chunk size")
+			}
+		})
+	}
+}
+
+func TestHeaderAlgorithmTamper(t *testing.T) {
 	id, recipient := generateTestIdentity(t)
 
 	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, 4*1024)
+	w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: AlgorithmAES})
 	if err != nil {
 		t.Fatalf("encrypt: %v", err)
 	}
@@ -177,16 +260,73 @@ func TestAESGCMHeaderChunkSizeTamper(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	raw := ciphertext.Bytes()
-	offset := stanzaChunkSizeOffset(t, raw)
-	binary.BigEndian.PutUint32(raw[offset:offset+4], 8*1024)
-
-	r, err := AESGCMDecrypt(bytes.NewReader(raw), id)
-	if err != nil {
-		t.Fatalf("decrypt init: %v", err)
+	raw := append([]byte(nil), ciphertext.Bytes()...)
+	if len(raw) < 2 {
+		t.Fatal("ciphertext too short")
 	}
-	if _, err := io.ReadAll(r); err == nil {
-		t.Fatal("expected authentication error for tampered chunk size")
+	raw[1] = 0xff
+
+	if _, err := Decrypt(bytes.NewReader(raw), id); err == nil {
+		t.Fatal("expected header parse error for unknown algorithm")
+	}
+}
+
+func TestReadStanzaHeaderRejectsUnsetAlgorithm(t *testing.T) {
+	id, recipient := generateTestIdentity(t)
+
+	var ciphertext bytes.Buffer
+	w, err := Encrypt(&ciphertext, recipient, Options{Algorithm: AlgorithmAES})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if _, err := w.Write([]byte("tamper me")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	raw := append([]byte(nil), ciphertext.Bytes()...)
+	raw[1] = 0x00
+
+	if _, err := Decrypt(bytes.NewReader(raw), id); err == nil {
+		t.Fatal("expected header parse error for unset algorithm")
+	}
+}
+
+func TestEncryptDefaultAlgorithmUsesRecommendation(t *testing.T) {
+	id, recipient := generateTestIdentity(t)
+
+	var ciphertext bytes.Buffer
+	w, err := Encrypt(&ciphertext, recipient, Options{})
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if _, err := w.Write([]byte("recommended cipher")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	raw := ciphertext.Bytes()
+	if len(raw) < 2 {
+		t.Fatal("ciphertext too short")
+	}
+	got, err := parseAlgorithmID(raw[1])
+	if err != nil {
+		t.Fatalf("parse algorithm id: %v", err)
+	}
+	if got != RecommendedCipher() {
+		t.Fatalf("expected algorithm %v, got %v", RecommendedCipher(), got)
+	}
+
+	r, err := Decrypt(bytes.NewReader(raw), id)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatalf("read: %v", err)
 	}
 }
 
@@ -205,23 +345,26 @@ func BenchmarkEncryptThroughput(b *testing.B) {
 	for _, sz := range aeadBenchSizes {
 		data := make([]byte, sz.n)
 		rand.Read(data)
-		b.Run(sz.name+"/aesgcm", func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				w, err := AESGCMEncrypt(io.Discard, recipient, 0)
-				if err != nil {
-					b.Fatal(err)
+		for _, algorithm := range testAlgorithms {
+			algorithm := algorithm
+			b.Run(sz.name+"/"+algorithmBenchmarkName(algorithm), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					w, err := Encrypt(io.Discard, recipient, Options{Algorithm: algorithm})
+					if err != nil {
+						b.Fatal(err)
+					}
+					if _, err := w.Write(data); err != nil {
+						b.Fatal(err)
+					}
+					if err := w.Close(); err != nil {
+						b.Fatal(err)
+					}
 				}
-				if _, err := w.Write(data); err != nil {
-					b.Fatal(err)
-				}
-				if err := w.Close(); err != nil {
-					b.Fatal(err)
-				}
-			}
-			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
-		})
+				b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+			})
+		}
 		b.Run(sz.name+"/age", func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -247,22 +390,29 @@ func BenchmarkDecryptThroughput(b *testing.B) {
 	for _, sz := range aeadBenchSizes {
 		data := make([]byte, sz.n)
 		rand.Read(data)
-		aesCT := encryptAESForBench(b, data, recipient)
+
+		ciphertexts := map[Algorithm][]byte{
+			AlgorithmAES:      encryptForBench(b, AlgorithmAES, data, recipient),
+			AlgorithmChaCha20: encryptForBench(b, AlgorithmChaCha20, data, recipient),
+		}
 		ageCT := encryptAgeForBench(b, data, recipient)
-		b.Run(sz.name+"/aesgcm", func(b *testing.B) {
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				r, err := AESGCMDecrypt(bytes.NewReader(aesCT), id)
-				if err != nil {
-					b.Fatal(err)
+
+		for _, algorithm := range testAlgorithms {
+			b.Run(sz.name+"/"+algorithmBenchmarkName(algorithm), func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					r, err := Decrypt(bytes.NewReader(ciphertexts[algorithm]), id)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if _, err := io.Copy(io.Discard, r); err != nil {
+						b.Fatal(err)
+					}
 				}
-				if _, err := io.Copy(io.Discard, r); err != nil {
-					b.Fatal(err)
-				}
-			}
-			b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
-		})
+				b.ReportMetric(float64(b.N)*float64(sz.n)/b.Elapsed().Seconds()/1048576, "MiB/s")
+			})
+		}
 		b.Run(sz.name+"/age", func(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -280,18 +430,18 @@ func BenchmarkDecryptThroughput(b *testing.B) {
 	}
 }
 
-func encryptAESForBench(b *testing.B, plaintext []byte, recipient *age.X25519Recipient) []byte {
+func encryptForBench(b *testing.B, algorithm Algorithm, plaintext []byte, recipient *age.X25519Recipient) []byte {
 	b.Helper()
 	var buf bytes.Buffer
-	w, err := AESGCMEncrypt(&buf, recipient, 0)
+	w, err := Encrypt(&buf, recipient, Options{Algorithm: algorithm})
 	if err != nil {
-		b.Fatalf("aes encrypt setup: %v", err)
+		b.Fatalf("%s encrypt setup: %v", algorithmName(algorithm), err)
 	}
 	if _, err := w.Write(plaintext); err != nil {
-		b.Fatalf("aes encrypt write: %v", err)
+		b.Fatalf("%s encrypt write: %v", algorithmName(algorithm), err)
 	}
 	if err := w.Close(); err != nil {
-		b.Fatalf("aes encrypt close: %v", err)
+		b.Fatalf("%s encrypt close: %v", algorithmName(algorithm), err)
 	}
 	return buf.Bytes()
 }
@@ -312,71 +462,76 @@ func encryptAgeForBench(b *testing.B, plaintext []byte, recipient *age.X25519Rec
 	return buf.Bytes()
 }
 
-func BenchmarkAESGCMEncrypt(b *testing.B) {
+func BenchmarkEncryptLarge(b *testing.B) {
 	_, recipient := generateTestIdentity(b)
 	data := make([]byte, 64*1024*1024)
 	rand.Read(data)
 
-	b.SetBytes(int64(len(data)))
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		w, err := AESGCMEncrypt(io.Discard, recipient, aeadDefaultChunk)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if _, err := w.Write(data); err != nil {
-			b.Fatal(err)
-		}
-		if err := w.Close(); err != nil {
-			b.Fatal(err)
-		}
+	for _, algorithm := range testAlgorithms {
+		algorithm := algorithm
+		b.Run(algorithmBenchmarkName(algorithm), func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				w, err := Encrypt(io.Discard, recipient, Options{Algorithm: algorithm, ChunkSize: aeadDefaultChunk})
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := w.Write(data); err != nil {
+					b.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }
 
-func BenchmarkAESGCMDecrypt(b *testing.B) {
+func BenchmarkDecryptLarge(b *testing.B) {
 	id, recipient := generateTestIdentity(b)
 	data := make([]byte, 64*1024*1024)
 	rand.Read(data)
-
-	var ciphertext bytes.Buffer
-	w, err := AESGCMEncrypt(&ciphertext, recipient, 0)
-	if err != nil {
-		b.Fatal(err)
-	}
-	w.Write(data)
-	w.Close()
-	cipherBytes := ciphertext.Bytes()
-
 	discard := make([]byte, 64*1024)
 
-	b.SetBytes(int64(len(data)))
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		r, err := AESGCMDecrypt(bytes.NewReader(cipherBytes), id)
-		if err != nil {
-			b.Fatal(err)
-		}
-		for {
-			_, err := r.Read(discard)
-			if err == io.EOF {
-				break
+	ciphertexts := map[Algorithm][]byte{
+		AlgorithmAES:      encryptForBench(b, AlgorithmAES, data, recipient),
+		AlgorithmChaCha20: encryptForBench(b, AlgorithmChaCha20, data, recipient),
+	}
+
+	for _, algorithm := range testAlgorithms {
+		algorithm := algorithm
+		b.Run(algorithmBenchmarkName(algorithm), func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				r, err := Decrypt(bytes.NewReader(ciphertexts[algorithm]), id)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for {
+					_, err := r.Read(discard)
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
 			}
-			if err != nil {
-				b.Fatal(err)
-			}
-		}
+		})
 	}
 }
 
 func stanzaChunkSizeOffset(t testing.TB, ciphertext []byte) int {
 	t.Helper()
 	offset := 0
-	if len(ciphertext) < 1 {
+	if len(ciphertext) < 2 {
 		t.Fatal("ciphertext too short")
 	}
-	offset++
+	offset += 2
 
 	readU16 := func() int {
 		if offset+2 > len(ciphertext) {
@@ -408,4 +563,26 @@ func stanzaChunkSizeOffset(t testing.TB, ciphertext []byte) int {
 		t.Fatal("ciphertext missing chunk size")
 	}
 	return offset
+}
+
+func algorithmName(algorithm Algorithm) string {
+	switch algorithm {
+	case AlgorithmAES:
+		return string(algorithm)
+	case AlgorithmChaCha20:
+		return string(algorithm)
+	default:
+		return "unknown"
+	}
+}
+
+func algorithmBenchmarkName(algorithm Algorithm) string {
+	switch algorithm {
+	case AlgorithmAES:
+		return "aesgcm"
+	case AlgorithmChaCha20:
+		return "chacha20poly1305"
+	default:
+		return "unknown"
+	}
 }

--- a/server/internal/filexfer/ftcp/auth.go
+++ b/server/internal/filexfer/ftcp/auth.go
@@ -79,7 +79,7 @@ func processAUTHRequest(req Request, serverID *age.X25519Identity) (authResult, 
 		if b64Err != nil {
 			return authResult{}, errNotAuthorized
 		}
-		dec, err := encoding.AESGCMDecrypt(bytes.NewReader(blobBytes), serverID)
+		dec, err := encoding.Decrypt(bytes.NewReader(blobBytes), serverID)
 		if err != nil {
 			return authResult{}, errNotAuthorized
 		}

--- a/server/internal/filexfer/ftcp/server.go
+++ b/server/internal/filexfer/ftcp/server.go
@@ -168,7 +168,7 @@ func (s *connSession) run() error {
 		if authRes.recipient != nil {
 			switch authRes.encryptMode {
 			case "aes":
-				encOut, encErr := encoding.AESGCMEncrypt(s.conn, authRes.recipient, 0)
+				encOut, encErr := encoding.Encrypt(s.conn, authRes.recipient, encoding.Options{Algorithm: encoding.AlgorithmAES})
 				if encErr != nil {
 					return encErr
 				}
@@ -189,7 +189,7 @@ func (s *connSession) run() error {
 			}
 			switch authRes.encryptMode {
 			case "aes":
-				decIn, decErr := encoding.AESGCMDecrypt(br, s.serverID)
+				decIn, decErr := encoding.Decrypt(br, s.serverID)
 				if decErr != nil {
 					return protocolErr{code: "NOT_AUTHORIZED", message: "request decryption failed"}
 				}


### PR DESCRIPTION
## Summary

When hardware acceleration is present, AES-GCM significantly outperforms the ChaCha20-Poly1305 path embedded in `age` for bulk transfer crypto. In addition to the throughput gains, `age`’s extra terminal `Read` complicates long-lived TCP request/response flows and forces hacks like half-closing the socket to avoid hangs.

This change is the first step in keeping `age` for key management while replacing bulk stream encryption with our own transfer-oriented AEAD layer.

## What Changed

- Added a streaming AEAD codec that uses `age`/X25519 only for file-key exchange.
- Replaced the AES-only internal API with a generic AEAD API:
  - `Encrypt(...)`
  - `Decrypt(...)`
  - `Options{ChunkSize, Algorithm}`
- Added support for:
  - `aes` (`AES-GCM`)
  - `chacha20` (`ChaCha20-Poly1305`)
- Encoded the selected cipher in the AEAD stream header so decrypt can choose the correct implementation.
- Added `RecommendedCipher()` to prefer AES when the CPU reports AES hardware support, otherwise fall back to ChaCha20-Poly1305.
- Updated FTCP/client call sites to use the new AEAD API for the `"aes"` encrypted transport mode.
- Expanded fuzz tests, round-trip coverage, tamper cases, and benchmarks to cover both supported AEAD algorithms.

## Why

- On modern hardware with AES acceleration, AES-GCM is materially faster than the `age` bulk encryption path.
- Our codec avoids some protocol awkwardness in `age`, especially the extra EOF-confirming read that makes duplex TCP handling more fragile.
- This keeps the good part of `age` for this use case, key exchange and recipient/identity handling, while giving us control over the data plane.

## Benchmark

Environment: `linux/amd64`, `AMD Ryzen AI 9 HX 370 w/ Radeon 890M`

### Encryption Throughput

| Size | AES-GCM MiB/s | ChaCha20-Poly1305 MiB/s | age MiB/s |
|---|---:|---:|---:|
| 64 KiB | 392.7 | 416.1 | 249.0 |
| 1 MiB | 2639 | 1826 | 1560 |
| 4 MiB | 4152 | 2356 | 2419 |
| 10 MiB | 4863 | 2333 | 2340 |

### Decryption Throughput

| Size | AES-GCM MiB/s | ChaCha20-Poly1305 MiB/s | age MiB/s |
|---|---:|---:|---:|
| 64 KiB | 647.4 | 534.3 | 436.2 |
| 1 MiB | 3977 | 2173 | 1404 |
| 4 MiB | 4735 | 2485 | 1712 |
| 10 MiB | 4751 | 2478 | 1789 |

### Allocation Comparison

| Size | AES allocs/op | ChaCha allocs/op | age allocs/op |
|---|---:|---:|---:|
| 64 KiB encrypt | 76 | 75 | 114 |
| 64 KiB decrypt | 70 | 69 | 111 |
| 1 MiB decrypt | 85 | 84 | 129 |
| 10 MiB decrypt | 229 | 228 | 273 |

## Takeaways

- AES-GCM is the best default on this machine once hardware acceleration is available.
- Both custom AEAD implementations reduce allocations substantially versus `age`.
- ChaCha20-Poly1305 remains a useful fallback for machines without AES acceleration.
- This lays the groundwork for moving bulk crypto off `age` while preserving its existing key management model.
