### PR TITLE
Optimize performance

### DIFF
--- a/server/filexfer/client.go
+++ b/server/filexfer/client.go
@@ -22,6 +22,7 @@ import (
 
 	"filippo.io/age"
 	intencoding "github.com/jolynch/pinch/internal/filexfer/encoding"
+	intlimit "github.com/jolynch/pinch/internal/filexfer/limit"
 	"github.com/jolynch/pinch/utils"
 	"github.com/zeebo/xxh3"
 )
@@ -36,6 +37,13 @@ const (
 	LoadStrategyFast   = "fast"
 	LoadStrategyGentle = "gentle"
 )
+
+const defaultGentleCPUPct = intlimit.DefaultGentleCPUPct
+const defaultGentleBWPct = intlimit.DefaultGentleBWPct
+
+func NormalizeGentleCPUPct(v int) int { return intlimit.NormalizeGentleCPUPct(v) }
+
+func NormalizeGentleBWPct(v int) int { return intlimit.NormalizeGentleBWPct(v) }
 
 type DownloadStatus struct {
 	Started int `json:"started"`
@@ -257,11 +265,14 @@ type GetFilesRequest struct {
 	// BatchMaxBytes is the unit of parallel work for a single large file: when a file
 	// exceeds BatchMaxBytes, it is split into windows of this size and downloaded
 	// concurrently. The number of concurrent windows is bounded by
-	// FileRequestWindowBytes/BatchMaxBytes — e.g. a 1 MiB batch with a 10 MiB window
-	// allows up to 10 concurrent requests against that file, while a 10 MiB batch allows
-	// only one. BatchMaxBytes must be <= Client.FileRequestWindowBytes.
-	BatchMaxBytes   int64
-	ProgressUpdates chan<- DownloadProgressUpdate
+	// FileRequestWindowBytes/BatchMaxBytes unless SplitWindowWorkers is set to a
+	// lower cap. BatchMaxBytes must be <= Client.FileRequestWindowBytes.
+	BatchMaxBytes int64
+	// SplitWindowWorkers caps the number of concurrent windows for a single large
+	// file. Zero uses the legacy behavior of deriving concurrency from
+	// FileRequestWindowBytes/BatchMaxBytes.
+	SplitWindowWorkers int
+	ProgressUpdates    chan<- DownloadProgressUpdate
 }
 
 type GetFilesResponse struct {
@@ -274,9 +285,12 @@ type StartFromManifestRequest struct {
 	OutputWriter func(ManifestEntry, int64) (io.WriteCloser, func() error, error)
 	Concurrency  int
 	// BatchMaxBytes is the unit of parallel work per file. See GetFilesRequest.BatchMaxBytes.
-	BatchMaxBytes   int64
-	ProgressUpdates chan<- DownloadProgressUpdate
-	OnFileDone      func(StartFileDoneEvent)
+	BatchMaxBytes int64
+	// SplitWindowWorkers caps per-file split-window concurrency. See
+	// GetFilesRequest.SplitWindowWorkers.
+	SplitWindowWorkers int
+	ProgressUpdates    chan<- DownloadProgressUpdate
+	OnFileDone         func(StartFileDoneEvent)
 }
 
 type StartFileDoneEvent struct {
@@ -303,19 +317,24 @@ type GetManifestRequest struct {
 }
 
 type ProbeRequest struct {
-	Samples      int
-	ProbeBytes   int64
-	LoadStrategy string
+	Samples          int
+	ProbeBytes       int64
+	LoadStrategy     string
+	TransferID       string
+	ObservedLinkMbps int64
 }
 
 type ProbeResponse struct {
 	ServerCPU            int
 	ServerIODepth        int
+	GentleCPUPct         int
+	GentleBWPct          int
 	AvgLatencyMS         int64
 	LinkMbps             int64
 	SuggestedConcurrency int
 	ServerSendBufBytes   int64
 	SuggestedCipher      string // resolved cipher suggested for this connection (e.g. "aes", "chacha20", or "" if none)
+	ServerLimiterBps     int64  // server's current rate limiter in bytes/sec (0 = unlimited)
 }
 
 type GetManifestResponse struct {
@@ -1065,7 +1084,7 @@ func (c *Client) downloadManifestBatchSequential(
 	if windowBytes <= 0 {
 		windowBytes = defaultClientRequestWindowBytes
 	}
-	k := maxSplitWindowWorkers(windowBytes, req.BatchMaxBytes, len(plans))
+	k := maxSplitWindowWorkers(windowBytes, req.BatchMaxBytes, req.SplitWindowWorkers, len(plans))
 
 	var (
 		allFiles    []DownloadFileResponse
@@ -1197,7 +1216,7 @@ func (c *Client) downloadManifestBatchWindows(
 		}
 	}
 
-	maxWorkers := maxSplitWindowWorkers(c.FileRequestWindowBytes, req.BatchMaxBytes, len(windows))
+	maxWorkers := maxSplitWindowWorkers(c.FileRequestWindowBytes, req.BatchMaxBytes, req.SplitWindowWorkers, len(windows))
 	limiter := make(chan struct{}, maxWorkers)
 	results := make(chan splitWindowResult, len(windows))
 	var (
@@ -1338,14 +1357,25 @@ func buildSplitWindows(start int64, end int64, maxBytes int64) []splitWindow {
 	return windows
 }
 
-func maxSplitWindowWorkers(windowBytes int64, batchBytes int64, numWindows int) int {
-	if numWindows < 1 || batchBytes <= 0 {
-		return 1
+func splitWindowWorkerLimit(windowBytes int64, batchBytes int64, plannedWorkers int) int {
+	if batchBytes <= 0 {
+		return max(1, plannedWorkers)
 	}
 	if windowBytes <= 0 {
 		windowBytes = defaultClientRequestWindowBytes
 	}
-	return max(1, min(numWindows, int(windowBytes/batchBytes)))
+	derivedWorkers := max(1, int(windowBytes/batchBytes))
+	if plannedWorkers <= 0 {
+		return derivedWorkers
+	}
+	return max(1, min(plannedWorkers, derivedWorkers))
+}
+
+func maxSplitWindowWorkers(windowBytes int64, batchBytes int64, plannedWorkers int, numWindows int) int {
+	if numWindows < 1 || batchBytes <= 0 {
+		return 1
+	}
+	return max(1, min(numWindows, splitWindowWorkerLimit(windowBytes, batchBytes, plannedWorkers)))
 }
 
 func (c *Client) downloadSplitWindow(
@@ -1581,11 +1611,12 @@ func (c *Client) StartFromManifest(ctx context.Context, req StartFromManifestReq
 			}
 			startOne := time.Now()
 			downloadBatchResp, err := c.GetFiles(ctx, GetFilesRequest{
-				Manifest:        req.Manifest,
-				FileIDs:         fileIDs,
-				OutputWriter:    req.OutputWriter,
-				BatchMaxBytes:   batchMaxBytes,
-				ProgressUpdates: req.ProgressUpdates,
+				Manifest:           req.Manifest,
+				FileIDs:            fileIDs,
+				OutputWriter:       req.OutputWriter,
+				BatchMaxBytes:      batchMaxBytes,
+				SplitWindowWorkers: req.SplitWindowWorkers,
+				ProgressUpdates:    req.ProgressUpdates,
 			})
 			if err != nil {
 				errCh <- fmt.Errorf("batch first-id=%d count=%d: %w", batch[0].ID, len(batch), err)
@@ -1657,7 +1688,8 @@ func (c *Client) effectiveBatchMaxBytes(reqBatchMaxBytes int64) int64 {
 // concurrency and per-file parallelism (i.e. suggestedConcurrency / windowConcurrency < 2),
 // window concurrency is reduced to suggestedConcurrency so all slots go to
 // concurrent file downloads rather than per-file splitting. This happens
-// naturally in gentle mode where total concurrency = ceil(cpu/4).
+// naturally in gentle mode when the server advertises a low CPU budget
+// (25% by default).
 //
 //	Example (gentle, 24 cpu):  conc=6, winConc reduced to 6, perFile=1 → batch = windowBytes
 //	Example (gentle, 32 cpu):  conc=8, winConc=4, perFile=2 → batch = windowBytes/2
@@ -1669,59 +1701,118 @@ func (c *Client) effectiveBatchMaxBytes(reqBatchMaxBytes int64) int64 {
 //     SEND request, so there is no benefit in making it smaller than the socket
 //     buffer the OS has already allocated for the connection.
 //   - Ceiling: windowBytes. A batch larger than the window cannot be scheduled.
-func SuggestBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windowBytes int64, serverWmemBytes int64) int64 {
-	if windowBytes <= 0 {
-		return defaultClientBatchMaxBytes
+func SuggestBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windowBytes int64, serverWmemBytes int64, linkMbps int64) int64 {
+	return buildBatchSizePlan(suggestedConcurrency, windowConcurrency, windowBytes, serverWmemBytes, linkMbps).BatchMaxBytes
+}
+
+// BatchSizePlan captures the inputs and intermediate values used to compute
+// the batch size, for human-readable diagnostic output.
+type BatchSizePlan struct {
+	BatchMaxBytes      int64
+	ConcBatchBytes     int64 // batch from concurrency math before bw cap
+	BwCeilBytes        int64 // bandwidth ceiling (0 if not applied)
+	FloorBytes         int64 // socket buffer floor
+	WindowBytes        int64
+	SplitWindowWorkers int
+	SuggestedConc      int
+	EffectiveWinConc   int
+	PerFileWorkers     int
+	LinkMbps           int64
+}
+
+// ExplainBatchMaxBytes computes the batch size and returns a plan with
+// intermediate values suitable for diagnostic output.
+func ExplainBatchMaxBytes(suggestedConcurrency int, windowConcurrency int, windowBytes int64, serverWmemBytes int64, linkMbps int64) BatchSizePlan {
+	return buildBatchSizePlan(suggestedConcurrency, windowConcurrency, windowBytes, serverWmemBytes, linkMbps)
+}
+
+func buildBatchSizePlan(suggestedConcurrency int, windowConcurrency int, windowBytes int64, serverWmemBytes int64, linkMbps int64) BatchSizePlan {
+	plan := BatchSizePlan{
+		SuggestedConc: suggestedConcurrency,
+		WindowBytes:   windowBytes,
+		LinkMbps:      linkMbps,
 	}
-	// A single concurrent window should use the full transfer window. Splitting
-	// that lone stream into smaller batches only adds coordination overhead
-	// without creating additional across-file concurrency.
-	if windowConcurrency == 1 {
-		return largestPow2MiBWithin(windowBytes)
+	if windowBytes <= 0 || windowConcurrency == 1 {
+		plan.BatchMaxBytes = defaultClientBatchMaxBytes
+		if windowBytes > 0 {
+			plan.BatchMaxBytes = largestPow2MiBWithin(windowBytes)
+		}
+		plan.ConcBatchBytes = plan.BatchMaxBytes
+		plan.EffectiveWinConc = max(1, windowConcurrency)
+		plan.PerFileWorkers = 1
+		plan.SplitWindowWorkers = 1
+		return plan
 	}
+	conc := max(1, plan.SuggestedConc)
+	plan.EffectiveWinConc = effectiveWindowConcurrency(conc, windowConcurrency)
+	plan.PerFileWorkers = max(1, conc/plan.EffectiveWinConc)
+	const mib = int64(1 << 20)
+	if windowBytes < mib {
+		plan.ConcBatchBytes = windowBytes
+		plan.BatchMaxBytes = windowBytes
+		plan.SplitWindowWorkers = 1
+		return plan
+	}
+	plan.ConcBatchBytes = roundUpPow2MiB(windowBytes / int64(plan.PerFileWorkers))
+	batch := plan.ConcBatchBytes
+	if batch < mib {
+		plan.BatchMaxBytes = batch
+		plan.SplitWindowWorkers = splitWindowWorkerLimit(windowBytes, batch, plan.PerFileWorkers)
+		return plan
+	}
+	plan.BwCeilBytes = bandwidthCeilBatchBytes(linkMbps, conc)
+	if plan.BwCeilBytes >= mib {
+		batch = min(batch, plan.BwCeilBytes)
+	}
+	plan.FloorBytes = roundedSocketFloorBytes(serverWmemBytes)
+	batch = max(batch, plan.FloorBytes)
+	plan.BatchMaxBytes = min(batch, largestPow2MiBWithin(windowBytes))
+	plan.SplitWindowWorkers = splitWindowWorkerLimit(windowBytes, plan.BatchMaxBytes, plan.PerFileWorkers)
+	return plan
+}
+
+func effectiveWindowConcurrency(suggestedConcurrency int, windowConcurrency int) int {
 	if windowConcurrency <= 0 {
 		windowConcurrency = 4
 	}
-	if suggestedConcurrency <= 0 {
-		suggestedConcurrency = 1
+	if windowConcurrency == 1 {
+		return 1
 	}
-
-	// Auto-range window concurrency: if there isn't enough total concurrency
-	// to give each window at least 2 per-file workers, reduce window concurrency
-	// to match the total so all slots are used for parallel file downloads.
 	if suggestedConcurrency/windowConcurrency < 2 {
-		windowConcurrency = suggestedConcurrency
+		return suggestedConcurrency
 	}
-	perFileWorkers := max(1, suggestedConcurrency/windowConcurrency)
-	raw := windowBytes / int64(perFileWorkers)
+	return windowConcurrency
+}
 
-	// Round up to the nearest power-of-2 MiB.
+func roundUpPow2MiB(v int64) int64 {
 	const mib = int64(1 << 20)
-	if windowBytes < mib {
-		return windowBytes
+	if v <= 0 {
+		return 0
 	}
-	mibCount := max(int64(1), (raw+mib-1)/mib)
+	if v < mib {
+		return mib
+	}
+	if v == mib {
+		return v
+	}
+	mibCount := max(int64(1), (v+mib-1)/mib)
 	pow2 := int64(1)
 	for pow2 < mibCount {
 		pow2 <<= 1
 	}
-	batch := pow2 * mib
+	return pow2 * mib
+}
 
-	// Floor: a batch is one TCP SEND, so it should not be smaller than the
-	// socket buffer the OS allocated — sending less wastes a round-trip for
-	// data that would have fit in a single write/read cycle.
-	// Round the floor up to the nearest power-of-2 MiB so the result stays aligned.
-	rawFloor := max(serverWmemBytes, int64(utils.MaxSocketReadBufferBytes()))
-	floorMiB := max(int64(1), (rawFloor+mib-1)/mib)
-	floorPow2 := int64(1)
-	for floorPow2 < floorMiB {
-		floorPow2 <<= 1
+func bandwidthCeilBatchBytes(linkMbps int64, suggestedConcurrency int) int64 {
+	if linkMbps <= 0 {
+		return 0
 	}
-	batch = max(batch, floorPow2*mib)
+	perWorkerBytesPerSec := (linkMbps * 1_000_000 / 8) / int64(max(1, suggestedConcurrency))
+	return largestPow2MiBWithin(perWorkerBytesPerSec / 2)
+}
 
-	// Ceiling: a batch larger than the transfer window is meaningless.
-	// Round down to keep MiB alignment.
-	return min(batch, largestPow2MiBWithin(windowBytes))
+func roundedSocketFloorBytes(serverWmemBytes int64) int64 {
+	return roundUpPow2MiB(max(serverWmemBytes, int64(utils.MaxSocketReadBufferBytes())))
 }
 
 // largestPow2MiBWithin returns the largest power-of-2 multiple of MiB that is
@@ -1739,7 +1830,7 @@ func largestPow2MiBWithin(v int64) int64 {
 	return p * mib
 }
 
-func suggestedConcurrencyFromProbe(serverCPU int, ioDepth int, strategy string) int {
+func suggestedConcurrencyFromProbe(serverCPU int, ioDepth int, strategy string, gentleCPUPct int) int {
 	if serverCPU <= 0 {
 		serverCPU = runtime.NumCPU()
 	}
@@ -1748,11 +1839,12 @@ func suggestedConcurrencyFromProbe(serverCPU int, ioDepth int, strategy string) 
 	}
 	strategy = normalizeLoadStrategy(strategy)
 	if strategy == LoadStrategyGentle {
-		// Gentle: 25% of available CPUs, io-depth is ignored —
+		// Gentle: a server-advertised percent of available CPUs, io-depth is ignored —
 		// window concurrency and per-file parallelism are auto-ranged
 		// in SuggestBatchMaxBytes to fill this budget.
-		value := serverCPU / 4
-		if serverCPU%4 != 0 {
+		gentleCPUPct = NormalizeGentleCPUPct(gentleCPUPct)
+		value := (serverCPU * gentleCPUPct) / 100
+		if (serverCPU*gentleCPUPct)%100 != 0 {
 			value++
 		}
 		return value
@@ -1792,14 +1884,14 @@ func (c *Client) ProbeLink(ctx context.Context, req ProbeRequest) (ProbeResponse
 
 	probeResults := make([]probeResponse, 0, samples)
 	for i := 0; i < samples; i++ {
-		result, err := c.probeTCP(ctx, probeBytes)
+		result, err := c.probeTCP(ctx, req, probeBytes)
 		if err != nil {
 			return ProbeResponse{}, fmt.Errorf("probe %d failed: %w", i+1, err)
 		}
 		probeResults = append(probeResults, result)
 	}
 	response := summarizeProbeSamples(probeResults, probeBytes)
-	response.SuggestedConcurrency = clampConcurrency(suggestedConcurrencyFromProbe(response.ServerCPU, response.ServerIODepth, loadStrategy))
+	response.SuggestedConcurrency = clampConcurrency(suggestedConcurrencyFromProbe(response.ServerCPU, response.ServerIODepth, loadStrategy, response.GentleCPUPct))
 
 	// Resolve the cipher name for display. If encryption is enabled,
 	// resolveTCPAuthState resolves "auto" to the server's recommendation.
@@ -1830,9 +1922,12 @@ func summarizeProbeSamples(results []probeResponse, probeBytes int64) ProbeRespo
 	return ProbeResponse{
 		ServerCPU:          serverCPU,
 		ServerIODepth:      serverIODepth,
+		GentleCPUPct:       results[0].GentleCPUPct,
+		GentleBWPct:        results[0].GentleBWPct,
 		AvgLatencyMS:       avgMS,
 		LinkMbps:           roundedMbps,
 		ServerSendBufBytes: serverSendBufBytes,
+		ServerLimiterBps:   results[len(results)-1].LimiterBps,
 	}
 }
 

--- a/server/filexfer/client_tcp.go
+++ b/server/filexfer/client_tcp.go
@@ -18,6 +18,7 @@ import (
 	"filippo.io/age"
 	"github.com/jolynch/pinch/internal/aead"
 	ftcp "github.com/jolynch/pinch/internal/filexfer/ftcp"
+	intlimit "github.com/jolynch/pinch/internal/filexfer/limit"
 )
 
 const maxTCPLineBytes = 4 * 1024 * 1024
@@ -34,12 +35,15 @@ type tcpAuthState struct {
 type probeResponse struct {
 	ServerCPU       int
 	ServerIODepth   int
+	GentleCPUPct    int
+	GentleBWPct     int
 	CTS0            int64
 	CTS1            int64
 	STS0            int64
 	STS1            int64
 	ProbeBytes      int64
 	ServerWmemBytes int64
+	LimiterBps      int64
 }
 
 func (c *Client) dialTCP(ctx context.Context) (net.Conn, error) {
@@ -658,7 +662,7 @@ func readTCPStatus(br *bufio.Reader) (string, error) {
 	return message, nil
 }
 
-func (c *Client) probeTCP(ctx context.Context, probeBytes int64) (probeResponse, error) {
+func (c *Client) probeTCP(ctx context.Context, req ProbeRequest, probeBytes int64) (probeResponse, error) {
 	if probeBytes <= 0 {
 		return probeResponse{}, errors.New("probe bytes must be > 0")
 	}
@@ -678,6 +682,12 @@ func (c *Client) probeTCP(ctx context.Context, probeBytes int64) (probeResponse,
 	cts0 := time.Now().UnixMilli()
 	localCPU := runtime.NumCPU()
 	cmd := fmt.Sprintf("PROBE cpu=%d probe-bytes=%d cts0=%d", localCPU, probeBytes, cts0)
+	if txferID := strings.TrimSpace(req.TransferID); txferID != "" {
+		cmd += " txferid=" + txferID
+		if req.ObservedLinkMbps > 0 {
+			cmd += " obs-link-mbps=" + strconv.FormatInt(req.ObservedLinkMbps, 10)
+		}
+	}
 	if err := c.sendTCPProbe(conn, state, cmd, probeBytes); err != nil {
 		return probeResponse{}, fmt.Errorf("send PROBE: %w", err)
 	}
@@ -795,18 +805,29 @@ func parseProbeResponseLine(line string) (probeResponse, error) {
 	if ioDepth <= 0 {
 		ioDepth = 1
 	}
+	gentleCPUPct, _ := strconv.Atoi(strings.TrimSpace(p["gentle-cpu-pct"]))
+	gentleCPUPct = intlimit.NormalizeGentleCPUPct(gentleCPUPct)
+	gentleBWPct, _ := strconv.Atoi(strings.TrimSpace(p["gentle-bw-pct"]))
+	gentleBWPct = intlimit.NormalizeGentleBWPct(gentleBWPct)
 	wmemBytes, _ := strconv.ParseInt(strings.TrimSpace(p["wmem"]), 10, 64)
 	if wmemBytes < 0 {
 		wmemBytes = 0
 	}
+	limiterBps, _ := strconv.ParseInt(strings.TrimSpace(p["limiter-bps"]), 10, 64)
+	if limiterBps < 0 {
+		limiterBps = 0
+	}
 	return probeResponse{
 		ServerCPU:       serverCPU,
 		ServerIODepth:   ioDepth,
+		GentleCPUPct:    gentleCPUPct,
+		GentleBWPct:     gentleBWPct,
 		CTS0:            cts0,
 		STS0:            sts0,
 		STS1:            sts1,
 		ProbeBytes:      probeBytes,
 		ServerWmemBytes: wmemBytes,
+		LimiterBps:      limiterBps,
 	}, nil
 }
 

--- a/server/filexfer/client_test.go
+++ b/server/filexfer/client_test.go
@@ -324,8 +324,8 @@ type singleDownloadRequest struct {
 	FileID          uint64
 	OutRoot         string
 	OutFile         string
-	Stdout        io.Writer
-	AckEveryBytes int64
+	Stdout          io.Writer
+	AckEveryBytes   int64
 	ResumeFromBytes int64
 	NoSync          bool
 	ProgressUpdates chan<- DownloadProgressUpdate
@@ -420,7 +420,7 @@ func downloadSingle(ctx context.Context, client *Client, req singleDownloadReque
 }
 
 func TestParseFXHeaderMaxWSizeHint(t *testing.T) {
-	meta, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none hash=xxh128:abc max-wsize=16777216 ts=1000")
+	meta, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none max-wsize=16777216 ts=1000")
 	if err != nil {
 		t.Fatalf("parseFXHeader failed: %v", err)
 	}
@@ -430,10 +430,10 @@ func TestParseFXHeaderMaxWSizeHint(t *testing.T) {
 }
 
 func TestParseFXHeaderInvalidMaxWSizeHint(t *testing.T) {
-	if _, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none hash=xxh128:abc max-wsize=-1 ts=1000"); err == nil {
+	if _, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none max-wsize=-1 ts=1000"); err == nil {
 		t.Fatalf("expected parse error for negative max-wsize")
 	}
-	if _, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none hash=xxh128:abc max-wsize=nope ts=1000"); err == nil {
+	if _, err := parseFXHeader("FX/1 7 offset=0 size=5 wsize=5 comp=none max-wsize=nope ts=1000"); err == nil {
 		t.Fatalf("expected parse error for malformed max-wsize")
 	}
 }
@@ -520,7 +520,6 @@ func TestFileStreamBufferHint(t *testing.T) {
 		t.Fatalf("expected clamp via effective policy, got=%d want=%d", got, effectiveFrameReadBufferSize(0, 4*1024*1024, 1))
 	}
 }
-
 
 func TestDownloadFileFromManifestWritesToOutRoot(t *testing.T) {
 	outRoot := t.TempDir()
@@ -1804,4 +1803,3 @@ func FuzzSuggestBatchMaxBytes(f *testing.F) {
 		}
 	})
 }
-

--- a/server/filexfer/client_test.go
+++ b/server/filexfer/client_test.go
@@ -188,9 +188,9 @@ func TestNewClientLoadStrategyOption(t *testing.T) {
 
 func TestSummarizeProbeResultsAndConcurrency(t *testing.T) {
 	results := []probeResponse{
-		{ServerCPU: 24, CTS0: 1000, CTS1: 1040, STS0: 1005, STS1: 1010},
-		{ServerCPU: 24, CTS0: 2000, CTS1: 2045, STS0: 2005, STS1: 2010},
-		{ServerCPU: 24, CTS0: 3000, CTS1: 3030, STS0: 3005, STS1: 3010},
+		{ServerCPU: 24, GentleCPUPct: 25, CTS0: 1000, CTS1: 1040, STS0: 1005, STS1: 1010},
+		{ServerCPU: 24, GentleCPUPct: 25, CTS0: 2000, CTS1: 2045, STS0: 2005, STS1: 2010},
+		{ServerCPU: 24, GentleCPUPct: 25, CTS0: 3000, CTS1: 3030, STS0: 3005, STS1: 3010},
 	}
 	summary := summarizeProbeSamples(results, 1*1024*1024)
 	if summary.ServerCPU != 24 {
@@ -202,11 +202,46 @@ func TestSummarizeProbeResultsAndConcurrency(t *testing.T) {
 	if summary.LinkMbps <= 0 {
 		t.Fatalf("expected rounded mbps > 0, got %d", summary.LinkMbps)
 	}
-	if got := suggestedConcurrencyFromProbe(24, 8, LoadStrategyGentle); got != 6 {
+	if got := suggestedConcurrencyFromProbe(24, 8, LoadStrategyGentle, 25); got != 6 {
 		t.Fatalf("expected gentle concurrency 6, got %d", got)
 	}
-	if got := suggestedConcurrencyFromProbe(24, 8, LoadStrategyFast); got != 192 {
+	if got := suggestedConcurrencyFromProbe(24, 8, LoadStrategyFast, 25); got != 192 {
 		t.Fatalf("expected fast concurrency 192, got %d", got)
+	}
+}
+
+func TestSuggestedConcurrencyFromProbeUsesServerGentlePercent(t *testing.T) {
+	if got := suggestedConcurrencyFromProbe(24, 8, LoadStrategyGentle, 50); got != 12 {
+		t.Fatalf("expected gentle concurrency 12, got %d", got)
+	}
+	if got := suggestedConcurrencyFromProbe(3, 8, LoadStrategyGentle, 34); got != 2 {
+		t.Fatalf("expected gentle concurrency 2, got %d", got)
+	}
+}
+
+func TestParseProbeResponseLineGentlePercents(t *testing.T) {
+	resp, err := parseProbeResponseLine("PROBE cpu=24 io-depth=8 cts0=100 sts0=110 sts1=120 probe-bytes=1024 wmem=4096 gentle-cpu-pct=30 gentle-bw-pct=40")
+	if err != nil {
+		t.Fatalf("parseProbeResponseLine failed: %v", err)
+	}
+	if resp.GentleCPUPct != 30 {
+		t.Fatalf("expected gentle cpu pct 30, got %d", resp.GentleCPUPct)
+	}
+	if resp.GentleBWPct != 40 {
+		t.Fatalf("expected gentle bw pct 40, got %d", resp.GentleBWPct)
+	}
+}
+
+func TestParseProbeResponseLineDefaultsGentlePercents(t *testing.T) {
+	resp, err := parseProbeResponseLine("PROBE cpu=24 io-depth=8 cts0=100 sts0=110 sts1=120 probe-bytes=1024 wmem=4096")
+	if err != nil {
+		t.Fatalf("parseProbeResponseLine failed: %v", err)
+	}
+	if resp.GentleCPUPct != defaultGentleCPUPct {
+		t.Fatalf("expected default gentle cpu pct %d, got %d", defaultGentleCPUPct, resp.GentleCPUPct)
+	}
+	if resp.GentleBWPct != defaultGentleBWPct {
+		t.Fatalf("expected default gentle bw pct %d, got %d", defaultGentleBWPct, resp.GentleBWPct)
 	}
 }
 
@@ -1120,6 +1155,95 @@ func TestGetFilesSplitsLargeSingleFileWindows(t *testing.T) {
 	}
 }
 
+func TestGetFilesSplitWindowWorkersCapsConcurrency(t *testing.T) {
+	outRoot := t.TempDir()
+	destPath := filepath.Join(outRoot, "big.bin")
+	if err := os.WriteFile(destPath, nil, 0o644); err != nil {
+		t.Fatalf("create destination: %v", err)
+	}
+
+	manifest := &Manifest{
+		TransferID: "txsplitcap",
+		Root:       "/remote",
+		Entries: []ManifestEntry{
+			{ID: 0, Size: 12, Path: "big.bin"},
+		},
+	}
+	payload := []byte("abcdefghijkl")
+
+	var (
+		mu          sync.Mutex
+		inFlight    int
+		maxInFlight int
+	)
+
+	srv := newFTCPTestServer(t, func(req intftcp.Request, out io.Writer) error {
+		switch req.Verb {
+		case intftcp.VerbSEND:
+			mu.Lock()
+			inFlight++
+			if inFlight > maxInFlight {
+				maxInFlight = inFlight
+			}
+			mu.Unlock()
+			defer func() {
+				mu.Lock()
+				inFlight--
+				mu.Unlock()
+			}()
+
+			sendParam := req.Params[len(req.Params)-1]
+			offset := int64(0)
+			if rawOffset := sendParam["offset"]; rawOffset != "" {
+				parsedOffset, err := strconv.ParseInt(rawOffset, 10, 64)
+				if err != nil {
+					return fmt.Errorf("parse offset: %w", err)
+				}
+				offset = parsedOffset
+			}
+			size, err := strconv.ParseInt(sendParam["size"], 10, 64)
+			if err != nil {
+				return fmt.Errorf("parse size: %w", err)
+			}
+			time.Sleep(50 * time.Millisecond)
+			_, err = io.WriteString(out, buildFXFrame(t, 0, "none", offset, payload[offset:offset+size], nil))
+			return err
+		case intftcp.VerbACK:
+			_, err := io.WriteString(out, "OK\r\n")
+			return err
+		default:
+			return fmt.Errorf("unexpected verb: %v", req.Verb)
+		}
+	})
+	defer srv.Close()
+
+	client := NewClient(srv.URL, WithFileRequestWindowBytes(12))
+	_, err := client.GetFiles(context.Background(), GetFilesRequest{
+		Manifest:           manifest,
+		FileIDs:            []uint64{0},
+		BatchMaxBytes:      4,
+		SplitWindowWorkers: 1,
+		ProgressUpdates:    make(chan DownloadProgressUpdate, 8),
+		OutputWriter: func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
+			fd, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE, 0o644)
+			if err != nil {
+				return nil, nil, err
+			}
+			if _, err := fd.Seek(offset, io.SeekStart); err != nil {
+				_ = fd.Close()
+				return nil, nil, err
+			}
+			return fd, func() error { return nil }, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetFiles failed: %v", err)
+	}
+	if maxInFlight != 1 {
+		t.Fatalf("expected split-window concurrency cap of 1, got %d", maxInFlight)
+	}
+}
+
 func TestGetFilesUsesMultiACK(t *testing.T) {
 	outRoot := t.TempDir()
 	manifest := &Manifest{
@@ -1711,72 +1835,112 @@ func TestSuggestBatchMaxBytes(t *testing.T) {
 		name                 string
 		conc, winConc        int
 		windowBytes, srvWmem int64
+		linkMbps             int64
 		want                 int64
 	}{
 		// Fast mode: 24 cpu * 8 io = 192 conc, winConc=4, perFile=48
 		// 1GiB/48 ≈ 21.3 MiB → ceil pow2 = 32 MiB
-		{"fast 24cpu*8io", 192, 4, 1 << 30, 4 * mib, 32 * mib},
+		// linkMbps=0 → no bw cap
+		{"fast 24cpu*8io", 192, 4, 1 << 30, 4 * mib, 0, 32 * mib},
 
 		// Fast mode: 2 cpu * 8 io = 16, winConc=4, perFile=4
 		// 1GiB/4 = 256 MiB
-		{"fast 2cpu*8io", 16, 4, 1 << 30, 4 * mib, 256 * mib},
+		{"fast 2cpu*8io", 16, 4, 1 << 30, 4 * mib, 0, 256 * mib},
 
 		// Gentle 24 cpu: conc=6, 6/4=1 < 2 → winConc=6, perFile=1
 		// batch = 1 GiB (capped at window)
-		{"gentle 24cpu conc=6", 6, 4, 1 << 30, 4 * mib, 1 << 30},
+		{"gentle 24cpu conc=6", 6, 4, 1 << 30, 4 * mib, 0, 1 << 30},
 
 		// Gentle 32 cpu: conc=8, 8/4=2 → perFile=2
 		// 1GiB/2 = 512 MiB
-		{"gentle 32cpu conc=8", 8, 4, 1 << 30, 4 * mib, 512 * mib},
+		{"gentle 32cpu conc=8", 8, 4, 1 << 30, 4 * mib, 0, 512 * mib},
 
 		// Zero concurrency defaults to 1
-		{"zero conc defaults", 0, 0, 1 << 30, 4 * mib, 1 << 30},
+		{"zero conc defaults", 0, 0, 1 << 30, 4 * mib, 0, 1 << 30},
 
 		// Negative values default safely
-		{"negative conc", -5, -2, 1 << 30, 4 * mib, 1 << 30},
+		{"negative conc", -5, -2, 1 << 30, 4 * mib, 0, 1 << 30},
 
 		// Socket buffer floor: 192 conc → 48 perFile → 1MiB batch
 		// but floor at max(4MiB, clientRmem)
-		{"batch floors at socket buf", 192, 4, 32 * mib, 4 * mib, max(4*mib, clientRmem)},
+		{"batch floors at socket buf", 192, 4, 32 * mib, 4 * mib, 0, max(4*mib, clientRmem)},
 
 		// Batch caps at window
-		{"batch caps at window", 2, 1, 8 * mib, 4 * mib, 8 * mib},
+		{"batch caps at window", 2, 1, 8 * mib, 4 * mib, 0, 8 * mib},
 
 		// Small window (< 1 MiB) returns window directly
-		{"sub-MiB window", 100, 4, 512 * 1024, 4 * mib, 512 * 1024},
+		{"sub-MiB window", 100, 4, 512 * 1024, 4 * mib, 0, 512 * 1024},
 
 		// High CPU fast mode: 256 cpu * 8 io = 2048 conc, winConc=4, perFile=512
 		// 1GiB/512 = 2 MiB
-		{"256 cpus fast", 2048, 4, 1 << 30, 4 * mib, max(4*mib, clientRmem)},
+		{"256 cpus fast", 2048, 4, 1 << 30, 4 * mib, 0, max(4*mib, clientRmem)},
+
+		// Bandwidth ceiling (500ms target): 8400 Mbps, conc=6
+		// perWorker=175 MB/s, 500ms=87.5 MB → pow2 down = 64 MiB
+		// Without bw cap: conc=6, 6/4<2 → winConc=6, perFile=1 → batch=1GiB
+		// With bw cap: min(1GiB, 64MiB) = 64 MiB
+		{"bw cap 8400mbps conc=6", 6, 4, 1 << 30, 4 * mib, 8400, 64 * mib},
+
+		// Bandwidth ceiling (500ms target): 1000 Mbps, conc=6
+		// perWorker=20.8 MB/s, 500ms=10.4 MB → pow2 down = 8 MiB
+		// Without bw cap: batch=1GiB; with bw cap: 8 MiB; floor max(4MiB,rmem) applies
+		{"bw cap 1000mbps conc=6", 6, 4, 1 << 30, 4 * mib, 1000, max(8*mib, clientRmem)},
+
+		// Bandwidth ceiling: very high link
+		// 100000 Mbps, conc=6 → perWorker≈2 GB/s, 500ms=1.04 GB → pow2 down = 512 MiB
+		// concurrency batch = 1GiB → min(1GiB, 512MiB) = 512 MiB
+		{"bw cap 100gbps", 6, 4, 1 << 30, 4 * mib, 100000, 512 * mib},
+
+		// Bandwidth ceiling with high concurrency:
+		// 8400 Mbps, conc=192 → perWorker=5.5 MB/s, 500ms=2.7 MB → pow2 down = 2 MiB
+		// concurrency batch = 32 MiB → min(32, 2) = 2 MiB, floor raises it
+		{"bw cap 8400mbps conc=192", 192, 4, 1 << 30, 4 * mib, 8400, max(4*mib, clientRmem)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := SuggestBatchMaxBytes(tt.conc, tt.winConc, tt.windowBytes, tt.srvWmem)
+			got := SuggestBatchMaxBytes(tt.conc, tt.winConc, tt.windowBytes, tt.srvWmem, tt.linkMbps)
 			if got != tt.want {
-				t.Fatalf("SuggestBatchMaxBytes(%d, %d, %d, %d) = %d, want %d",
-					tt.conc, tt.winConc, tt.windowBytes, tt.srvWmem, got, tt.want)
+				t.Fatalf("SuggestBatchMaxBytes(%d, %d, %d, %d, %d) = %d, want %d",
+					tt.conc, tt.winConc, tt.windowBytes, tt.srvWmem, tt.linkMbps, got, tt.want)
 			}
 		})
 	}
 }
 
+func TestExplainBatchMaxBytesBandwidthCapKeepsSplitWindowWorkers(t *testing.T) {
+	const mib = int64(1 << 20)
+	plan := ExplainBatchMaxBytes(6, 4, 1<<30, 4*mib, 8400)
+	if plan.BatchMaxBytes != 64*mib {
+		t.Fatalf("expected batch size 64 MiB, got %d", plan.BatchMaxBytes)
+	}
+	if plan.PerFileWorkers != 1 {
+		t.Fatalf("expected planned per-file workers to stay at 1, got %d", plan.PerFileWorkers)
+	}
+	if plan.SplitWindowWorkers != 1 {
+		t.Fatalf("expected split-window workers to stay capped at 1, got %d", plan.SplitWindowWorkers)
+	}
+}
+
 func FuzzSuggestBatchMaxBytes(f *testing.F) {
-	f.Add(192, 4, int64(1<<30), int64(4<<20))
-	f.Add(0, 0, int64(1<<30), int64(4<<20))
-	f.Add(-10, -5, int64(1<<20), int64(0))
-	f.Add(256, 128, int64(512<<20), int64(16<<20))
-	f.Add(6, 4, int64(1<<30), int64(4<<20))
-	f.Add(8, 4, int64(1<<30), int64(4<<20))
-	f.Add(1, 1, int64(1), int64(0))
-	f.Add(2048, 4, int64(1<<30), int64(4<<20))
-	f.Fuzz(func(t *testing.T, conc int, winConc int, windowBytes int64, serverWmem int64) {
+	f.Add(192, 4, int64(1<<30), int64(4<<20), int64(0))
+	f.Add(0, 0, int64(1<<30), int64(4<<20), int64(0))
+	f.Add(-10, -5, int64(1<<20), int64(0), int64(0))
+	f.Add(256, 128, int64(512<<20), int64(16<<20), int64(0))
+	f.Add(6, 4, int64(1<<30), int64(4<<20), int64(8400))
+	f.Add(8, 4, int64(1<<30), int64(4<<20), int64(1000))
+	f.Add(1, 1, int64(1), int64(0), int64(0))
+	f.Add(2048, 4, int64(1<<30), int64(4<<20), int64(100000))
+	f.Fuzz(func(t *testing.T, conc int, winConc int, windowBytes int64, serverWmem int64, linkMbps int64) {
 		if windowBytes <= 0 {
 			return
 		}
 		if serverWmem < 0 {
 			serverWmem = 0
 		}
-		got := SuggestBatchMaxBytes(conc, winConc, windowBytes, serverWmem)
+		if linkMbps < 0 {
+			linkMbps = 0
+		}
+		got := SuggestBatchMaxBytes(conc, winConc, windowBytes, serverWmem, linkMbps)
 		const mib = int64(1 << 20)
 
 		// Property 1: power of 2 MiB (when result >= 1 MiB)

--- a/server/filexfer/docs/PROTOCOL.md
+++ b/server/filexfer/docs/PROTOCOL.md
@@ -227,19 +227,30 @@ Returns transfer status JSON. Two forms:
 ## PROBE
 
 Latency/throughput probe used before `TXFER` so the client can send transfer hints.
+Clients may continue probing every 10s during an active transfer to refresh the
+server's observed link estimate for gentle limiting.
 
 ### Request
 
-`PROBE cpu=<client-cpu> probe-bytes=<n> cts0=<unix-ms>`
+`PROBE cpu=<client-cpu> probe-bytes=<n> cts0=<unix-ms> [txferid=<id>] [obs-link-mbps=<int>]`
 
 - request line is followed by exactly `probe-bytes` raw bytes.
 - `probe-bytes` must be `<= 32 MiB`.
+- `txferid` is optional and scopes periodic reprobe updates to an existing transfer.
+- `obs-link-mbps` is optional and reports the client's last measured link bandwidth.
+  When provided, the server uses it to refresh the per-transfer observed link estimate
+  for gentle limiting.
 
 ### Response
 
 - first line:
-  - `PROBE cpu=<server-cpu> cts0=<echo-client-cts0> sts0=<unix-ms> sts1=<unix-ms> probe-bytes=<n>`
+  - `PROBE cpu=<server-cpu> cts0=<echo-client-cts0> sts0=<unix-ms> sts1=<unix-ms> probe-bytes=<n> [io-depth=<int>] [wmem=<bytes>] gentle-cpu-pct=<int> gentle-bw-pct=<int> [limiter-bps=<bytes/sec>]`
 - then exactly `probe-bytes` raw bytes.
 - terminal status line: `OK` or `ERR ...`.
+- `gentle-cpu-pct` is the server-advertised CPU budget clients use when computing
+  gentle suggested concurrency.
+- `gentle-bw-pct` is the server-advertised share of observed link bandwidth used
+  to derive gentle transfer rate limits.
+- `PROBE` traffic itself is not rate-limited.
 
 Clients typically run 3 probes, compute a rounded link estimate, choose mode/concurrency, then issue `TXFER` with those required hints.

--- a/server/internal/cmd/filexfercli/cli.go
+++ b/server/internal/cmd/filexfercli/cli.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"math/rand"
 	"net"
 	"os"
@@ -28,7 +29,6 @@ import (
 	. "github.com/jolynch/pinch/filexfer"
 	"github.com/jolynch/pinch/internal/filexfer"
 	"github.com/jolynch/pinch/internal/filexfer/encoding"
-	"github.com/jolynch/pinch/utils"
 	"github.com/zeebo/xxh3"
 )
 
@@ -58,12 +58,56 @@ const defaultVerboseProgressInterval = 2 * time.Second
 const defaultCLIProbeBytes int64 = 1 * 1024 * 1024
 const defaultVerifySampleFrameSize int64 = 8 * 1024 * 1024
 const verifySampleBytes int64 = 8
+const defaultTransferProbeRefreshInterval = 10 * time.Second
+const fixedWidthProgressBytesWidth = 10
+const fixedWidthProgressRateWidth = 13
+const maxTransferErrorLines = 5
+
+var transferProbeRefreshInterval = defaultTransferProbeRefreshInterval
 
 var syncPromptInput io.Reader = os.Stdin
 
 var syncPromptIsTerminal = func() bool {
 	stat, err := os.Stdin.Stat()
 	return err == nil && stat != nil && (stat.Mode()&os.ModeCharDevice) != 0
+}
+
+func formatStartBatchCause(plan BatchSizePlan) string {
+	baseCause := "window"
+	bwActive := plan.BwCeilBytes > 0 && plan.BwCeilBytes < plan.ConcBatchBytes
+	baseBatch := plan.ConcBatchBytes
+	if bwActive {
+		baseCause = "bw-probe"
+		baseBatch = plan.BwCeilBytes
+	}
+	if plan.BatchMaxBytes == plan.FloorBytes && plan.FloorBytes > baseBatch {
+		if baseCause == "bw-probe" {
+			return "bw-probe, raised to socket size"
+		}
+		return "floor"
+	}
+	return baseCause
+}
+
+func formatStartBatchWindowLine(windowBytes int64, plan BatchSizePlan) string {
+	return fmt.Sprintf(
+		"    window: %s / %d per-file-workers = %s",
+		encoding.HumanBytes(windowBytes),
+		plan.PerFileWorkers,
+		encoding.HumanBytes(plan.ConcBatchBytes),
+	)
+}
+
+func formatStartBatchProbeLine(linkMiBPerSec int64, suggestedConcurrency int, plan BatchSizePlan) string {
+	if plan.BwCeilBytes <= 0 || plan.BwCeilBytes >= plan.ConcBatchBytes {
+		return ""
+	}
+	return fmt.Sprintf(
+		"    bw-probe: %d MiB/s / %d conc / 2 = %s",
+		linkMiBPerSec,
+		suggestedConcurrency,
+		encoding.HumanBytes(plan.BwCeilBytes),
+	)
 }
 
 type synchronizedWriter struct {
@@ -95,6 +139,66 @@ func (cw *countingWriter) Close() error {
 		return c.Close()
 	}
 	return nil
+}
+
+type probeReporter struct {
+	stop           func()
+	limiterBps     atomic.Int64 // server's current rate limiter (bytes/sec)
+	linkMbps       atomic.Int64 // latest probe-derived link bandwidth (megabits/sec)
+	lastProbeUnixS atomic.Int64 // unix seconds of most recent successful probe
+}
+
+func startTransferProbeReporter(ctx context.Context, client *Client, transferID string, strategy string, probeBytes int64, initialObservedLinkMbps int64) *probeReporter {
+	pr := &probeReporter{stop: func() {}}
+	if client == nil || strings.TrimSpace(transferID) == "" {
+		return pr
+	}
+	if probeBytes <= 0 {
+		probeBytes = defaultCLIProbeBytes
+	}
+	if strings.TrimSpace(strategy) == "" {
+		strategy = LoadStrategyFast
+	}
+	probeCtx, cancel := context.WithCancel(ctx)
+	pr.stop = cancel
+	var observed atomic.Int64
+	if initialObservedLinkMbps > 0 {
+		observed.Store(initialObservedLinkMbps)
+		pr.linkMbps.Store(initialObservedLinkMbps)
+		pr.lastProbeUnixS.Store(time.Now().Unix())
+	}
+	go func() {
+		ticker := time.NewTicker(transferProbeRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-probeCtx.Done():
+				return
+			case <-ticker.C:
+				resp, err := client.ProbeLink(probeCtx, ProbeRequest{
+					Samples:          1,
+					ProbeBytes:       probeBytes,
+					LoadStrategy:     strategy,
+					TransferID:       transferID,
+					ObservedLinkMbps: observed.Load(),
+				})
+				if err != nil {
+					continue
+				}
+				if resp.LinkMbps > 0 {
+					observed.Store(resp.LinkMbps)
+					pr.linkMbps.Store(resp.LinkMbps)
+				}
+				if resp.ServerLimiterBps > 0 {
+					pr.limiterBps.Store(resp.ServerLimiterBps)
+				} else {
+					pr.limiterBps.Store(0)
+				}
+				pr.lastProbeUnixS.Store(time.Now().Unix())
+			}
+		}
+	}()
+	return pr
 }
 
 const defaultFileListener = "127.0.0.1:3453"
@@ -366,7 +470,7 @@ type transferArgs struct {
 	encMode      string
 	loadStrategy string
 	probeBytes   int64
-	verbose      bool
+	verbosity    int
 	maxChunk     int
 	deadlineMS   int64
 }
@@ -383,7 +487,7 @@ type syncArgs struct {
 	compress            string
 	noSync              bool
 	skipWrite           bool
-	verbose             bool
+	verbosity           int
 	yes                 bool
 	probeBytes          int64
 	traceFile           string
@@ -425,6 +529,32 @@ func cleanupCopyState(targetDir string, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func verbosityFromFlags(progress bool, verbose bool) int {
+	if verbose {
+		return 2
+	}
+	if progress {
+		return 1
+	}
+	return 0
+}
+
+func printTransferErrors(stderr io.Writer, phase string, errs []error, verbosity int) {
+	if stderr == nil || len(errs) == 0 {
+		return
+	}
+	printed := len(errs)
+	if verbosity < 2 && printed > maxTransferErrorLines {
+		printed = maxTransferErrorLines
+	}
+	for _, err := range errs[:printed] {
+		fmt.Fprintf(stderr, "%s error: %v\n", phase, err)
+	}
+	if verbosity < 2 && len(errs) > printed {
+		fmt.Fprintf(stderr, "%s failed with %d errors\n", phase, len(errs))
+	}
 }
 
 func runCopyCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writer) int {
@@ -567,7 +697,7 @@ func runCopyCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 		encMode:      encMode,
 		loadStrategy: loadStrategy,
 		probeBytes:   probeBytes,
-		verbose:      false,
+		verbosity:    0,
 		maxChunk:     0,
 		deadlineMS:   deadlineMS,
 	}
@@ -595,7 +725,7 @@ func runCopyCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 			compress:            compress,
 			noSync:              cfg.skipFsync,
 			skipWrite:           cfg.skipWrite,
-			verbose:             cfg.verbose,
+			verbosity:           verbosityFromFlags(false, cfg.verbose),
 			yes:                 cfg.yes,
 			probeBytes:          probeBytes,
 			traceFile:           cfg.traceFile,
@@ -606,12 +736,7 @@ func runCopyCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 			return code
 		}
 	} else {
-		verbosity := 0
-		if cfg.verbose {
-			verbosity = 2
-		} else if cfg.progress {
-			verbosity = 1
-		}
+		verbosity := verbosityFromFlags(cfg.progress, cfg.verbose)
 		startCfg := startArgs{
 			targetDir:           cfg.localDst,
 			agePublicKey:        agePublicKey,
@@ -1061,7 +1186,7 @@ func runTransferCLI(serverURL string, args []string, stdout io.Writer, stderr io
 		encMode:      resolvedEncMode,
 		loadStrategy: loadStrategy,
 		probeBytes:   probeBytes,
-		verbose:      verbose,
+		verbosity:    verbosityFromFlags(false, verbose),
 		maxChunk:     maxChunk,
 		deadlineMS:   deadlineMS,
 	}, stdout, stderr)
@@ -1098,7 +1223,7 @@ func runTransfer(serverURL string, cfg transferArgs, stdout io.Writer, stderr io
 	}
 	fmt.Fprintf(
 		stdout,
-		"transfer-probe : strategy=%s cipher=%s avg_ms=%d est_link=%dMbps srv-conc=(%d cpu * %d io = %d)\n",
+		"txfer-probe   : strategy=%s cipher=%s avg_ms=%d est_link=%dMbps srv-conc=(%d cpu * %d io = %d)\n",
 		cfg.loadStrategy,
 		cipherDisplay,
 		probeResult.AvgLatencyMS,
@@ -1107,7 +1232,7 @@ func runTransfer(serverURL string, cfg transferArgs, stdout io.Writer, stderr io
 	)
 	manifestResp, err := client.GetManifest(context.Background(), GetManifestRequest{
 		Directory:    cfg.sourceDir,
-		Verbose:      cfg.verbose,
+		Verbose:      cfg.verbosity >= 2,
 		MaxChunkSize: cfg.maxChunk,
 		Mode:         cfg.loadStrategy,
 		LinkMbps:     probeResult.LinkMbps,
@@ -1134,14 +1259,14 @@ func runTransfer(serverURL string, cfg transferArgs, stdout io.Writer, stderr io
 	}
 	fmt.Fprintf(
 		stdout,
-		"transfer-loaded: tid[%s] %d files (%s) from [%s] elapsed=%s\n",
+		"txfer-loaded  : tid[%s] %d files (%s) from [%s] elapsed=%s\n",
 		manifest.TransferID,
 		len(manifest.Entries),
 		encoding.HumanBytes(total),
 		manifest.Root,
 		time.Since(start).Round(time.Millisecond),
 	)
-	fmt.Fprintf(stderr, "transfer-state : >(%s)\n", ps.ServerManifestPath)
+	fmt.Fprintf(stderr, "txfer-state   : >(%s)\n", ps.ServerManifestPath)
 
 	return 0
 }
@@ -1215,11 +1340,12 @@ func runStatusCLI(serverURL string, args []string, stdout io.Writer, stderr io.W
 	for _, s := range listResp.Statuses {
 		fmt.Fprintf(
 			stdout,
-			"[%s] source=[%s] files=[%d/%d](%.1f%%) bytes=[%s/%s](%.1f%%)\n",
+			"[%s] source=[%s] files=[%d/%d](%.1f%%) [%s/%s](%.1f%%)\n",
 			s.TransferID,
 			s.Directory,
 			s.Done, s.NumFiles, s.PercentFiles,
-			encoding.HumanBytes(s.DoneSize), encoding.HumanBytes(s.TotalSize), s.PercentBytes,
+			encoding.HumanBytesFixedWidth(s.DoneSize, fixedWidthProgressBytesWidth),
+			encoding.HumanBytesFixedWidth(s.TotalSize, fixedWidthProgressBytesWidth), s.PercentBytes,
 		)
 	}
 	return 0
@@ -1300,15 +1426,16 @@ func pollTransferStatus(client *Client, txferID string, manifest *Manifest, prog
 		if rateBps > 0 && s.TotalSize > s.DoneSize {
 			remaining := float64(s.TotalSize - s.DoneSize)
 			etaSec := remaining / rateBps
-			etaPart = fmt.Sprintf(" eta=%s", (time.Duration(etaSec * float64(time.Second))).Round(time.Second))
+			etaPart = fmt.Sprintf(" eta=%s", fixedWidthETA(time.Duration(etaSec*float64(time.Second))))
 		}
 		fmt.Fprintf(
 			stdout,
-			"server: files=[%d/%d](%.1f%%) bytes=[%s/%s](%.1f%%) rate=%s%s\n",
+			"server: files=[%d/%d](%.1f%%) [%s/%s](%.1f%%) rate=%s%s\n",
 			s.Done, s.NumFiles, s.PercentFiles,
-			encoding.HumanBytes(s.DoneSize), encoding.HumanBytes(s.TotalSize),
+			encoding.HumanBytesFixedWidth(s.DoneSize, fixedWidthProgressBytesWidth),
+			encoding.HumanBytesFixedWidth(s.TotalSize, fixedWidthProgressBytesWidth),
 			s.PercentBytes,
-			encoding.HumanRate(rateBps), etaPart,
+			encoding.HumanRateFixedWidth(rateBps, fixedWidthProgressRateWidth), etaPart,
 		)
 		if hasLocal {
 			localDoneFiles, localTotalFiles, localDoneBytes, localTotalBytes := computeLocalProgress(manifest, progressPath)
@@ -1333,9 +1460,10 @@ func pollTransferStatus(client *Client, txferID string, manifest *Manifest, prog
 			}
 			fmt.Fprintf(
 				stdout,
-				"client: files=[%d/%d](%.1f%%) bytes=[%s/%s](%.1f%%)\n",
+				"client: files=[%d/%d](%.1f%%) [%s/%s](%.1f%%)\n",
 				peakLocalDoneFiles, localTotalFiles, localPctFiles,
-				encoding.HumanBytes(peakLocalDoneBytes), encoding.HumanBytes(localTotalBytes),
+				encoding.HumanBytesFixedWidth(peakLocalDoneBytes, fixedWidthProgressBytesWidth),
+				encoding.HumanBytesFixedWidth(localTotalBytes, fixedWidthProgressBytesWidth),
 				localPctBytes,
 			)
 		}
@@ -1495,12 +1623,18 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 	if probe, probeErr := client.ProbeLink(context.Background(), ProbeRequest{Samples: 1, ProbeBytes: 1}); probeErr == nil {
 		miniProbe = probe
 	}
-	batchSize := SuggestBatchMaxBytes(
+	batchPlan := ExplainBatchMaxBytes(
 		miniProbe.SuggestedConcurrency,
 		client.WindowConcurrency,
 		client.FileRequestWindowBytes,
 		miniProbe.ServerSendBufBytes,
+		miniProbe.LinkMbps,
 	)
+	batchSize := batchPlan.BatchMaxBytes
+	transferCtx, cancelTransfer := context.WithCancel(context.Background())
+	defer cancelTransfer()
+	probeInfo := startTransferProbeReporter(transferCtx, client, manifest.TransferID, LoadStrategyFast, defaultCLIProbeBytes, miniProbe.LinkMbps)
+	defer probeInfo.stop()
 
 	start := time.Now()
 	progressUpdates := make(chan DownloadProgressUpdate, 128)
@@ -1521,13 +1655,12 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 		}
 	}()
 
+	var totalCopied atomic.Int64
 	var stopStatusPolling func()
-	if progress {
-		stopStatusPolling = startVerboseStatusPolling(manifest.TransferID, client, stderr)
+	if verbosityFromFlags(progress, verbose) >= 1 {
+		stopStatusPolling = startVerboseStatusPolling(manifest.TransferID, client, &totalCopied, entry.Size, probeInfo, stderr)
 		defer stopStatusPolling()
 	}
-
-	var totalCopied atomic.Int64
 	outputWriter := func(me ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
 		w, syncFn, wErr := openDownloadOutput(me, offset, outputPath, stdout, skipFsync)
 		if wErr != nil {
@@ -1550,12 +1683,13 @@ func runGetCLI(serverURL string, args []string, stdout io.Writer, stderr io.Writ
 		defer func() { stopProgressFile(err == nil) }()
 	}
 
-	downloadBatchResp, err := client.GetFiles(context.Background(), GetFilesRequest{
-		Manifest:        manifest,
-		FileIDs:         []uint64{0},
-		BatchMaxBytes:   batchSize,
-		OutputWriter:    outputWriter,
-		ProgressUpdates: progressUpdates,
+	downloadBatchResp, err := client.GetFiles(transferCtx, GetFilesRequest{
+		Manifest:           manifest,
+		FileIDs:            []uint64{0},
+		BatchMaxBytes:      batchSize,
+		SplitWindowWorkers: batchPlan.SplitWindowWorkers,
+		OutputWriter:       outputWriter,
+		ProgressUpdates:    progressUpdates,
 	})
 	elapsed := time.Since(start)
 	if err != nil {
@@ -1656,6 +1790,7 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 		fmt.Fprintln(stderr, "--concurrency must be > 0")
 		return 2
 	}
+	verbosity := verbosityFromFlags(false, verbose)
 	return runSync(serverURL, syncArgs{
 		sourceDir:           sourceDir,
 		targetDir:           cf.Arg(0),
@@ -1668,7 +1803,7 @@ func runSyncCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wri
 		compress:            compress,
 		noSync:              noSync,
 		skipWrite:           skipWrite,
-		verbose:             verbose,
+		verbosity:           verbosity,
 		yes:                 yes,
 		probeBytes:          probeBytes,
 		traceFile:           traceFile,
@@ -1736,12 +1871,14 @@ func runSync(serverURL string, cfg syncArgs, stdout io.Writer, stderr io.Writer)
 			fmt.Fprintf(stderr, "probe failed: %v\n", err)
 			return 1
 		}
-		batchSize := SuggestBatchMaxBytes(
+		batchPlan := ExplainBatchMaxBytes(
 			probeResult.SuggestedConcurrency,
 			client.WindowConcurrency,
 			client.FileRequestWindowBytes,
 			probeResult.ServerSendBufBytes,
+			effectiveModeLinkMbps(loadStrategy, probeResult.LinkMbps, probeResult.GentleBWPct),
 		)
+		batchSize := batchPlan.BatchMaxBytes
 
 		// SYNC: send old manifest, receive new manifest + removed paths.
 		syncResp, err := client.SyncManifest(context.Background(), SyncManifestRequest{
@@ -1884,7 +2021,7 @@ func runSync(serverURL string, cfg syncArgs, stdout io.Writer, stderr io.Writer)
 		progressUpdates := make(chan DownloadProgressUpdate, 1024)
 		entryByID := manifestEntriesByID(mergedManifest)
 		var onProgressUpdate func(DownloadProgressUpdate)
-		if cfg.verbose {
+		if cfg.verbosity >= 2 {
 			progressReporter := newVerboseProgressReporter(stderr)
 			onProgressUpdate = progressReporter.ReportUpdate
 		}
@@ -1945,14 +2082,17 @@ func runSync(serverURL string, cfg syncArgs, stdout io.Writer, stderr io.Writer)
 			failures = append(failures, err)
 			failuresMu.Unlock()
 		}
+		transferCtx, cancelTransfer := context.WithCancel(context.Background())
+		probeInfo := startTransferProbeReporter(transferCtx, client, mergedManifest.TransferID, mergedManifest.Mode, cfg.probeBytes, mergedManifest.LinkMbps)
 
-		startResp, err := client.StartFromManifest(context.Background(), StartFromManifestRequest{
-			Manifest:        mergedManifest,
-			Entries:         pendingEntries,
-			OutputWriter:    outputWriter,
-			Concurrency:     effectiveConcurrency,
-			BatchMaxBytes:   batchSize,
-			ProgressUpdates: progressUpdates,
+		startResp, err := client.StartFromManifest(transferCtx, StartFromManifestRequest{
+			Manifest:           mergedManifest,
+			Entries:            pendingEntries,
+			OutputWriter:       outputWriter,
+			Concurrency:        effectiveConcurrency,
+			BatchMaxBytes:      batchSize,
+			SplitWindowWorkers: batchPlan.SplitWindowWorkers,
+			ProgressUpdates:    progressUpdates,
 			OnFileDone: func(evt StartFileDoneEvent) {
 				entry, ok := entryByID[evt.File.Meta.FileID]
 				if !ok {
@@ -1972,6 +2112,8 @@ func runSync(serverURL string, cfg syncArgs, stdout io.Writer, stderr io.Writer)
 				printStartFileSummary(stdout, evt.File.Meta.FileID, destPath, evt.File.Meta, evt.File.LocalFileHash, evt.File.WindowChecksumPassed, evt.File.WindowChecksumTotal, evt.Elapsed)
 			},
 		})
+		probeInfo.stop()
+		cancelTransfer()
 		stopProgress()
 		applyProgressStateToManifest(mergedManifest, mergedProgress)
 		if err != nil {
@@ -1987,9 +2129,7 @@ func runSync(serverURL string, cfg syncArgs, stdout io.Writer, stderr io.Writer)
 		failuresMu.Lock()
 		finalFailures := append([]error(nil), failures...)
 		failuresMu.Unlock()
-		for _, err := range finalFailures {
-			fmt.Fprintf(stderr, "sync error: %v\n", err)
-		}
+		printTransferErrors(stderr, "sync", finalFailures, cfg.verbosity)
 
 		elapsedAll := time.Since(startAll)
 		overallSpeed := 0.0
@@ -2067,12 +2207,7 @@ func runStartCLI(serverURL string, args []string, stdout io.Writer, stderr io.Wr
 		fmt.Fprintf(stderr, "invalid --progress-file-interval: %v\n", err)
 		return 2
 	}
-	verbosity := 0
-	if verbose {
-		verbosity = 2
-	} else if progress {
-		verbosity = 1
-	}
+	verbosity := verbosityFromFlags(progress, verbose)
 	var deadlineMS int64
 	if deadlineRaw != "" {
 		d, err := time.ParseDuration(deadlineRaw)
@@ -2215,23 +2350,57 @@ func runStart(serverURL string, cfg startArgs, stdout io.Writer, stderr io.Write
 	if probe, probeErr := client.ProbeLink(context.Background(), ProbeRequest{Samples: 1, ProbeBytes: 1}); probeErr == nil {
 		miniProbe = probe
 	}
+	rawLinkMbps := max(manifest.LinkMbps, miniProbe.LinkMbps)
+	gentleCPUPct := NormalizeGentleCPUPct(miniProbe.GentleCPUPct)
+	gentleBWPct := NormalizeGentleBWPct(miniProbe.GentleBWPct)
+	effectiveLinkMbps := effectiveModeLinkMbps(loadStrategy, rawLinkMbps, gentleBWPct)
 	batchSize := SuggestBatchMaxBytes(
 		miniProbe.SuggestedConcurrency,
 		client.WindowConcurrency,
 		client.FileRequestWindowBytes,
 		miniProbe.ServerSendBufBytes,
+		effectiveLinkMbps,
 	)
-	fmt.Fprintf(
-		stdout,
-		"start-plan: strategy=%s link=%dMbps conc=%d srv-conc=(%d cpu * %d io = %d) batch=%s cli-sendbuf=%s srv-recvbuf=%s\n",
-		loadStrategy,
-		manifest.LinkMbps,
-		effectiveConcurrency,
-		miniProbe.ServerCPU, miniProbe.ServerIODepth, miniProbe.SuggestedConcurrency,
-		encoding.HumanBytes(batchSize),
-		encoding.HumanBytes(miniProbe.ServerSendBufBytes),
-		encoding.HumanBytes(int64(utils.MaxSocketReadBufferBytes())),
+	batchPlan := ExplainBatchMaxBytes(
+		miniProbe.SuggestedConcurrency,
+		client.WindowConcurrency,
+		client.FileRequestWindowBytes,
+		miniProbe.ServerSendBufBytes,
+		effectiveLinkMbps,
 	)
+	linkMiBPerSec := rawLinkMbps * 1_000_000 / 8 / (1 << 20)
+	effectiveLinkMiBPerSec := effectiveLinkMbps * 1_000_000 / 8 / (1 << 20)
+	fmt.Fprintf(stdout, "start-plan:\n")
+	if loadStrategy == LoadStrategyGentle {
+		fmt.Fprintf(stdout, "  server: %d cpu, %d io-depth, %d Mbps (%d MiB/s), %d%% gentle-cpu, %d%% gentle-bw\n",
+			miniProbe.ServerCPU, miniProbe.ServerIODepth, rawLinkMbps, linkMiBPerSec, gentleCPUPct, gentleBWPct)
+		fmt.Fprintf(stdout, "  mode: [%s] → concurrency = %d cpu * %d%% = %d, bw-limit = %d MiB/s * %d%% = %d MiB/s\n",
+			loadStrategy, miniProbe.ServerCPU, gentleCPUPct, miniProbe.SuggestedConcurrency, linkMiBPerSec, gentleBWPct, effectiveLinkMiBPerSec)
+	} else {
+		fmt.Fprintf(stdout, "  server: %d cpu, %d io-depth, %d Mbps (%d MiB/s)\n",
+			miniProbe.ServerCPU, miniProbe.ServerIODepth, rawLinkMbps, linkMiBPerSec)
+		fmt.Fprintf(stdout, "  mode: [%s] → concurrency = %d cpu * %d io-depth = %d, bw-limit = none\n",
+			loadStrategy, miniProbe.ServerCPU, miniProbe.ServerIODepth, miniProbe.SuggestedConcurrency)
+	}
+	if cfg.concurrencyExplicit {
+		fmt.Fprintf(stdout, "  concurrency: %d (override from --concurrency, server suggested %d)\n",
+			effectiveConcurrency, miniProbe.SuggestedConcurrency)
+	} else {
+		fmt.Fprintf(stdout, "  concurrency: %d\n", effectiveConcurrency)
+	}
+	fmt.Fprintf(stdout, "    window: %d\n", batchPlan.EffectiveWinConc)
+	fmt.Fprintf(stdout, "    batch-per-window: %d\n", batchPlan.PerFileWorkers)
+	fmt.Fprintf(stdout, "  batch: %s (from %s)\n",
+		encoding.HumanBytes(batchPlan.BatchMaxBytes),
+		formatStartBatchCause(batchPlan))
+	fmt.Fprintln(stdout, formatStartBatchWindowLine(client.FileRequestWindowBytes, batchPlan))
+	if bwProbeLine := formatStartBatchProbeLine(effectiveLinkMiBPerSec, miniProbe.SuggestedConcurrency, batchPlan); bwProbeLine != "" {
+		fmt.Fprintln(stdout, bwProbeLine)
+	}
+	transferCtx, cancelTransfer := context.WithCancel(context.Background())
+	defer cancelTransfer()
+	probeInfo := startTransferProbeReporter(transferCtx, client, manifest.TransferID, loadStrategy, defaultCLIProbeBytes, manifest.LinkMbps)
+	defer probeInfo.stop()
 
 	startAll := time.Now()
 	var completed int64
@@ -2245,11 +2414,6 @@ func runStart(serverURL string, cfg startArgs, stdout io.Writer, stderr io.Write
 		failuresMu.Lock()
 		failures = append(failures, err)
 		failuresMu.Unlock()
-	}
-	var stopStatusPolling func()
-	if cfg.verbosity >= 1 {
-		stopStatusPolling = startVerboseStatusPolling(txferID, client, stderr)
-		defer stopStatusPolling()
 	}
 	pendingEntries := make([]ManifestEntry, 0, len(manifest.Entries))
 	for _, entry := range manifest.Entries {
@@ -2271,6 +2435,15 @@ func runStart(serverURL string, cfg startArgs, stdout io.Writer, stderr io.Write
 		pendingEntries = append(pendingEntries, entry)
 	}
 	var totalCopied atomic.Int64
+	var totalPendingBytes int64
+	for _, e := range pendingEntries {
+		totalPendingBytes += e.Size
+	}
+	var stopStatusPolling func()
+	if cfg.verbosity >= 1 {
+		stopStatusPolling = startVerboseStatusPolling(txferID, client, &totalCopied, totalPendingBytes, probeInfo, stderr)
+		defer stopStatusPolling()
+	}
 	outputWriter := func(entry ManifestEntry, offset int64) (io.WriteCloser, func() error, error) {
 		destPath := resolveDownloadDestinationPath(entry, outRoot, "")
 		w, syncFn, err := openDownloadOutput(entry, offset, destPath, nil, cfg.noSync)
@@ -2296,13 +2469,14 @@ func runStart(serverURL string, cfg startArgs, stdout io.Writer, stderr io.Write
 		})
 		defer func() { stopProgressFile(len(failures) == 0) }()
 	}
-	startResp, err := client.StartFromManifest(context.Background(), StartFromManifestRequest{
-		Manifest:        manifest,
-		Entries:         pendingEntries,
-		OutputWriter:    outputWriter,
-		Concurrency:     effectiveConcurrency,
-		BatchMaxBytes:   batchSize,
-		ProgressUpdates: progressUpdates,
+	startResp, err := client.StartFromManifest(transferCtx, StartFromManifestRequest{
+		Manifest:           manifest,
+		Entries:            pendingEntries,
+		OutputWriter:       outputWriter,
+		Concurrency:        effectiveConcurrency,
+		BatchMaxBytes:      batchSize,
+		SplitWindowWorkers: batchPlan.SplitWindowWorkers,
+		ProgressUpdates:    progressUpdates,
 		OnFileDone: func(evt StartFileDoneEvent) {
 			entry, ok := entryByID[evt.File.Meta.FileID]
 			if !ok {
@@ -2342,9 +2516,7 @@ func runStart(serverURL string, cfg startArgs, stdout io.Writer, stderr io.Write
 	failuresMu.Lock()
 	finalFailures := append([]error(nil), failures...)
 	failuresMu.Unlock()
-	for _, err := range finalFailures {
-		fmt.Fprintf(stderr, "start error: %v\n", err)
-	}
+	printTransferErrors(stderr, "start", finalFailures, cfg.verbosity)
 
 	elapsedAll := time.Since(startAll)
 	overallSpeed := 0.0
@@ -2424,14 +2596,14 @@ func printStartFileSummary(stdout io.Writer, fileID uint64, path string, meta Fi
 	io.WriteString(stdout, sb.String())
 }
 
-func startVerboseStatusPolling(txferID string, client *Client, stderr io.Writer) func() {
+func startVerboseStatusPolling(txferID string, client *Client, localCopied *atomic.Int64, localTotalBytes int64, probe *probeReporter, stderr io.Writer) func() {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		ticker := time.NewTicker(defaultVerboseProgressInterval)
 		defer ticker.Stop()
-		var prevDoneSize int64
+		var prevCopied int64
 		prevTime := time.Now()
 		for {
 			statusResp, statusErr := client.GetStatus(ctx, GetStatusRequest{
@@ -2444,29 +2616,43 @@ func startVerboseStatusPolling(txferID string, client *Client, stderr io.Writer)
 				fmt.Fprintf(stderr, "status refresh failed: %v\n", statusErr)
 			} else {
 				s := statusResp.Status
+				// Use local byte counter for rate/ETA — it updates on every
+				// frame write, not just on ACK, so rate is never stuck at 0
+				// while data is actively streaming.
+				copied := localCopied.Load()
+				totalBytes := localTotalBytes
+				if s.TotalSize > totalBytes {
+					totalBytes = s.TotalSize
+				}
 				now := time.Now()
 				dt := now.Sub(prevTime).Seconds()
 				var rateBps float64
 				if dt > 0 {
-					rateBps = float64(s.DoneSize-prevDoneSize) / dt
+					rateBps = float64(copied-prevCopied) / dt
 				}
-				prevDoneSize = s.DoneSize
+				prevCopied = copied
 				prevTime = now
 
-				etaPart := ""
-				if rateBps > 0 && s.TotalSize > s.DoneSize {
-					remaining := float64(s.TotalSize - s.DoneSize)
-					etaSec := remaining / rateBps
-					etaPart = fmt.Sprintf(" eta=%s", (time.Duration(etaSec * float64(time.Second))).Round(time.Second))
+				var pctBytes float64
+				if totalBytes > 0 {
+					pctBytes = float64(copied) * 100 / float64(totalBytes)
 				}
+				etaDisplay := fixedWidthETANA()
+				if rateBps > 0 && totalBytes > copied {
+					remaining := float64(totalBytes - copied)
+					etaSec := remaining / rateBps
+					etaDisplay = fixedWidthETA(time.Duration(etaSec * float64(time.Second)))
+				}
+				probePart := formatProbeRateSuffix(now, rateBps, probe)
 				fmt.Fprintf(
 					stderr,
-					"transfer-progress:[%6s/%6s](%5.1f%%) bytes=[%8s/%8s](%5.1f%%) rate=%6s%s\n",
+					"txfer-progress:[%6s/%6s](%5.1f%%) [%s/%s](%5.1f%%) [eta:%s]@[%s]%s\n",
 					encoding.HumanCount(s.Done, 6), encoding.HumanCount(uint64(s.NumFiles), 6),
 					s.PercentFiles,
-					encoding.HumanBytes(s.DoneSize), encoding.HumanBytes(s.TotalSize),
-					s.PercentBytes,
-					encoding.HumanRate(rateBps), etaPart,
+					encoding.HumanBytesFixedWidth(copied, fixedWidthProgressBytesWidth),
+					encoding.HumanBytesFixedWidth(totalBytes, fixedWidthProgressBytesWidth),
+					pctBytes,
+					etaDisplay, encoding.HumanRateFixedWidth(rateBps, fixedWidthProgressRateWidth), probePart,
 				)
 			}
 			select {
@@ -3249,7 +3435,7 @@ func (r *verboseProgressReporter) emitLocked(fileID uint64, st *verboseProgressS
 	eta := "n/a"
 	if rateBps > 0 && copied < st.targetBytes {
 		remaining := st.targetBytes - copied
-		eta = humanETA(time.Duration(float64(remaining) / rateBps * float64(time.Second)))
+		eta = fixedWidthETA(time.Duration(float64(remaining) / rateBps * float64(time.Second)))
 	}
 
 	fmt.Fprintf(
@@ -3257,10 +3443,10 @@ func (r *verboseProgressReporter) emitLocked(fileID uint64, st *verboseProgressS
 		"file progress[%d]: %d%% bytes=%s/%s [%s] rate=%s eta=%s\n",
 		fileID,
 		pct,
-		encoding.HumanBytes(copied),
-		encoding.HumanBytes(st.targetBytes),
-		encoding.HumanBytes(acked),
-		encoding.HumanRate(rateBps),
+		encoding.HumanBytesFixedWidth(copied, fixedWidthProgressBytesWidth),
+		encoding.HumanBytesFixedWidth(st.targetBytes, fixedWidthProgressBytesWidth),
+		encoding.HumanBytesFixedWidth(acked, fixedWidthProgressBytesWidth),
+		encoding.HumanRateFixedWidth(rateBps, fixedWidthProgressRateWidth),
 		eta,
 	)
 
@@ -3286,6 +3472,85 @@ func humanETA(d time.Duration) string {
 		return "0s"
 	}
 	return d.Round(time.Second).String()
+}
+
+func fixedWidthETA(d time.Duration) string {
+	return fmt.Sprintf("%5s", compactETA(d))
+}
+
+func fixedWidthETANA() string {
+	return fmt.Sprintf("%5s", "n/a")
+}
+
+func fixedWidthHumanDuration(d time.Duration) string {
+	return fmt.Sprintf("%4s", humanETA(d))
+}
+
+func compactETA(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	seconds := d.Round(time.Second).Seconds()
+	switch {
+	case seconds < 60:
+		return fmt.Sprintf("%.0fs", seconds)
+	case seconds < 60*60:
+		return fmt.Sprintf("%.1fm", seconds/60)
+	case seconds < 24*60*60:
+		return fmt.Sprintf("%.1fh", seconds/3600)
+	case seconds < 7*24*60*60:
+		return fmt.Sprintf("%.1fd", seconds/(24*3600))
+	default:
+		return fmt.Sprintf("%.1fw", seconds/(7*24*3600))
+	}
+}
+
+func effectiveModeLinkMbps(strategy string, linkMbps int64, gentleBWPct int) int64 {
+	if !strings.EqualFold(strings.TrimSpace(strategy), LoadStrategyGentle) || linkMbps <= 0 {
+		return linkMbps
+	}
+	gentleBWPct = NormalizeGentleBWPct(gentleBWPct)
+	scaled := (linkMbps * int64(gentleBWPct)) / 100
+	if (linkMbps*int64(gentleBWPct))%100 != 0 {
+		scaled++
+	}
+	return max(int64(1), scaled)
+}
+
+func effectiveProbeLimitBps(probe *probeReporter) (limitBps int64, basis string, hardLimit bool) {
+	if probe == nil {
+		return 0, "", false
+	}
+	if limiterBps := probe.limiterBps.Load(); limiterBps > 0 {
+		return limiterBps, "limit", true
+	}
+	if linkMbps := probe.linkMbps.Load(); linkMbps > 0 {
+		return (linkMbps * 1_000_000) / 8, "link", false
+	}
+	return 0, "", false
+}
+
+func formatProbeRateSuffix(now time.Time, rateBps float64, probe *probeReporter) string {
+	if probe == nil {
+		return ""
+	}
+	limitBps, basis, hardLimit := effectiveProbeLimitBps(probe)
+	lastProbeUnixS := probe.lastProbeUnixS.Load()
+	if limitBps <= 0 || basis == "" || lastProbeUnixS <= 0 {
+		return ""
+	}
+	pctOfLimit := int(math.Round((rateBps * 100) / float64(limitBps)))
+	if pctOfLimit < 0 {
+		pctOfLimit = 0
+	}
+	if !hardLimit && pctOfLimit > 100 {
+		pctOfLimit = 100
+	}
+	age := now.Sub(time.Unix(lastProbeUnixS, 0))
+	if age < 0 {
+		age = 0
+	}
+	return fmt.Sprintf(" (%d%% of %s=%s @%s)", pctOfLimit, basis, encoding.HumanRate(float64(limitBps)), fixedWidthHumanDuration(age))
 }
 
 func printFileMetrics(stdout io.Writer, txferID string, fileID uint64, path string, meta FileFrameMeta, localFileHash string, elapsed time.Duration) {

--- a/server/internal/cmd/filexfercli/cli_test.go
+++ b/server/internal/cmd/filexfercli/cli_test.go
@@ -3,6 +3,7 @@ package filexfercli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -305,7 +306,7 @@ func writeCLIProbeResponse(req intftcp.Request, out io.Writer) error {
 	if err != nil || n < 0 {
 		return fmt.Errorf("invalid probe-bytes: %q", req.Params[0]["probe-bytes"])
 	}
-	if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 cts0=%s sts0=10 sts1=11 probe-bytes=%d\n", cts0, n)); err != nil {
+	if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 io-depth=1 cts0=%s sts0=10 sts1=11 probe-bytes=%d gentle-cpu-pct=25 gentle-bw-pct=25\n", cts0, n)); err != nil {
 		return err
 	}
 	if n > 0 {
@@ -371,7 +372,7 @@ func TestRunCLITransferAndGet(t *testing.T) {
 			if err != nil || n < 0 {
 				return fmt.Errorf("invalid probe-bytes: %q", req.Params[0]["probe-bytes"])
 			}
-			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 cts0=%s sts0=10 sts1=11 probe-bytes=%d\n", cts0, n)); err != nil {
+			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 io-depth=1 cts0=%s sts0=10 sts1=11 probe-bytes=%d gentle-cpu-pct=25 gentle-bw-pct=25\n", cts0, n)); err != nil {
 				return err
 			}
 			if n > 0 {
@@ -502,7 +503,7 @@ func TestRunCLITransferWithEncryptAuto(t *testing.T) {
 			if err != nil || n < 0 {
 				return fmt.Errorf("invalid probe-bytes: %q", req.Params[0]["probe-bytes"])
 			}
-			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 cts0=%s sts0=10 sts1=11 probe-bytes=%d\n", cts0, n)); err != nil {
+			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 io-depth=1 cts0=%s sts0=10 sts1=11 probe-bytes=%d gentle-cpu-pct=25 gentle-bw-pct=25\n", cts0, n)); err != nil {
 				return err
 			}
 			if n > 0 {
@@ -561,7 +562,7 @@ func TestRunCLITransferWithEncryptAES(t *testing.T) {
 			if err != nil || n < 0 {
 				return fmt.Errorf("invalid probe-bytes: %q", req.Params[0]["probe-bytes"])
 			}
-			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 cts0=%s sts0=10 sts1=11 probe-bytes=%d\n", cts0, n)); err != nil {
+			if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 io-depth=1 cts0=%s sts0=10 sts1=11 probe-bytes=%d gentle-cpu-pct=25 gentle-bw-pct=25\n", cts0, n)); err != nil {
 				return err
 			}
 			if n > 0 {
@@ -650,9 +651,14 @@ func TestRunCLIStartDownloadsAll(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("start: expected 0, got %d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "start-plan: strategy=gentle link=700Mbps conc=2") ||
-		!strings.Contains(stdout.String(), "srv-conc=(24 cpu * 1 io = 6)") {
-		t.Fatalf("missing start plan line: %s", stdout.String())
+	out := stdout.String()
+	if !strings.Contains(out, "mode: [gentle]") ||
+		!strings.Contains(out, "concurrency: 2 (override from --concurrency") ||
+		!strings.Contains(out, "    window: ") ||
+		!strings.Contains(out, "    batch-per-window: ") ||
+		!strings.Contains(out, "server: 24 cpu, 1 io-depth") ||
+		!strings.Contains(out, "25% gentle-bw") {
+		t.Fatalf("missing start plan output: %s", out)
 	}
 	// After start, staging dir is renamed to target dir.
 	for _, p := range []string{"a.txt", "b.txt"} {
@@ -699,9 +705,13 @@ func TestRunCLIStartUsesManifestConcurrencyDefault(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("start: expected 0, got %d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "start-plan: strategy=fast link=1200Mbps conc=5") ||
-		!strings.Contains(stdout.String(), "srv-conc=(24 cpu * 1 io = 24)") {
-		t.Fatalf("missing default start plan line: %s", stdout.String())
+	out := stdout.String()
+	if !strings.Contains(out, "mode: [fast]") ||
+		!strings.Contains(out, "concurrency: 5") ||
+		!strings.Contains(out, "    window: ") ||
+		!strings.Contains(out, "    batch-per-window: ") ||
+		!strings.Contains(out, "server: 24 cpu, 1 io-depth") {
+		t.Fatalf("missing default start plan output: %s", out)
 	}
 }
 
@@ -767,7 +777,6 @@ func TestRunCLIStartDiscardSkipsTargetMutationAndLocalManifest(t *testing.T) {
 	}
 }
 
-
 func TestRunCLIStartDiscardSkipsCompletedMetadataRefresh(t *testing.T) {
 	tmp := t.TempDir()
 	manifestRaw := strings.Join([]string{
@@ -798,6 +807,369 @@ func TestRunCLIStartDiscardSkipsCompletedMetadataRefresh(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(targetDir, "a.txt")); !os.IsNotExist(err) {
 		t.Fatalf("expected discarded output to be absent, stat err=%v", err)
+	}
+}
+
+func TestStartTransferProbeReporterIncludesTransferTelemetry(t *testing.T) {
+	oldInterval := transferProbeRefreshInterval
+	transferProbeRefreshInterval = 5 * time.Millisecond
+	defer func() { transferProbeRefreshInterval = oldInterval }()
+
+	var probeCount atomic.Int64
+	var firstTransferID atomic.Value
+	var firstObserved atomic.Int64
+
+	srv := newFTCPTestServer(t, func(req intftcp.Request, out io.Writer) error {
+		if req.Verb != intftcp.VerbPROBE {
+			return fmt.Errorf("unexpected verb: %v", req.Verb)
+		}
+		probeCount.Add(1)
+		firstTransferID.CompareAndSwap(nil, req.Params[0]["txferid"])
+		if probeCount.Load() == 1 {
+			obs, _ := strconv.ParseInt(strings.TrimSpace(req.Params[0]["obs-link-mbps"]), 10, 64)
+			firstObserved.Store(obs)
+		}
+		cts0 := req.Params[0]["cts0"]
+		n, err := strconv.Atoi(req.Params[0]["probe-bytes"])
+		if err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, fmt.Sprintf("PROBE cpu=24 io-depth=8 cts0=%s sts0=10 sts1=11 probe-bytes=%d wmem=4096 gentle-cpu-pct=25 gentle-bw-pct=25\n", cts0, n)); err != nil {
+			return err
+		}
+		if n > 0 {
+			if _, err := out.Write(make([]byte, n)); err != nil {
+				return err
+			}
+		}
+		_, err = io.WriteString(out, "OK\r\n")
+		return err
+	})
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	pr := startTransferProbeReporter(ctx, client, "txprobe", LoadStrategyFast, 1024, 700)
+	defer pr.stop()
+	defer cancel()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if probeCount.Load() > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if probeCount.Load() == 0 {
+		t.Fatalf("expected at least one probe refresh")
+	}
+	gotTxferID, _ := firstTransferID.Load().(string)
+	if gotTxferID != "txprobe" {
+		t.Fatalf("unexpected transfer id: %q", gotTxferID)
+	}
+	if firstObserved.Load() != 700 {
+		t.Fatalf("unexpected initial observed link mbps: %d", firstObserved.Load())
+	}
+	if got := pr.linkMbps.Load(); got <= 0 {
+		t.Fatalf("expected probe reporter to retain link mbps, got %d", got)
+	}
+	if got := pr.lastProbeUnixS.Load(); got <= 0 {
+		t.Fatalf("expected probe reporter to retain last probe timestamp, got %d", got)
+	}
+}
+
+func TestFormatProbeRateSuffixUsesServerLimiter(t *testing.T) {
+	now := time.Unix(200, 0)
+	var probe probeReporter
+	probe.limiterBps.Store(100 * 1024 * 1024)
+	probe.linkMbps.Store(9000)
+	probe.lastProbeUnixS.Store(now.Add(-2 * time.Second).Unix())
+
+	got := formatProbeRateSuffix(now, 25*1024*1024, &probe)
+	if got != " (25% of limit=100.00 MiB/s @  2s)" {
+		t.Fatalf("unexpected limiter suffix: %q", got)
+	}
+}
+
+func TestFormatProbeRateSuffixFallsBackToLinkBandwidth(t *testing.T) {
+	now := time.Unix(300, 0)
+	var probe probeReporter
+	probe.linkMbps.Store(800)
+	probe.lastProbeUnixS.Store(now.Add(-10 * time.Second).Unix())
+
+	got := formatProbeRateSuffix(now, 50*1_000_000, &probe)
+	if got != " (50% of link=95.37 MiB/s @ 10s)" {
+		t.Fatalf("unexpected link suffix: %q", got)
+	}
+}
+
+func TestFormatProbeRateSuffixClampsLinkFallbackTo100Pct(t *testing.T) {
+	now := time.Unix(320, 0)
+	var probe probeReporter
+	probe.linkMbps.Store(800)
+	probe.lastProbeUnixS.Store(now.Add(-3 * time.Second).Unix())
+
+	got := formatProbeRateSuffix(now, 400*1_000_000, &probe)
+	if got != " (100% of link=95.37 MiB/s @  3s)" {
+		t.Fatalf("unexpected clamped link suffix: %q", got)
+	}
+}
+
+func TestFormatStartBatchCause(t *testing.T) {
+	const mib = int64(1 << 20)
+	tests := []struct {
+		name string
+		plan BatchSizePlan
+		want string
+	}{
+		{
+			name: "window",
+			plan: BatchSizePlan{
+				BatchMaxBytes:  32 * mib,
+				ConcBatchBytes: 32 * mib,
+				FloorBytes:     16 * mib,
+			},
+			want: "window",
+		},
+		{
+			name: "bw-probe",
+			plan: BatchSizePlan{
+				BatchMaxBytes:  4 * mib,
+				ConcBatchBytes: 32 * mib,
+				BwCeilBytes:    4 * mib,
+				FloorBytes:     1 * mib,
+			},
+			want: "bw-probe",
+		},
+		{
+			name: "bw-probe raised to socket size",
+			plan: BatchSizePlan{
+				BatchMaxBytes:  16 * mib,
+				ConcBatchBytes: 32 * mib,
+				BwCeilBytes:    4 * mib,
+				FloorBytes:     16 * mib,
+			},
+			want: "bw-probe, raised to socket size",
+		},
+		{
+			name: "floor",
+			plan: BatchSizePlan{
+				BatchMaxBytes:  16 * mib,
+				ConcBatchBytes: 8 * mib,
+				FloorBytes:     16 * mib,
+			},
+			want: "floor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatStartBatchCause(tt.plan); got != tt.want {
+				t.Fatalf("formatStartBatchCause() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatStartBatchWindowLine(t *testing.T) {
+	const mib = int64(1 << 20)
+	got := formatStartBatchWindowLine(512*mib, BatchSizePlan{
+		PerFileWorkers: 24,
+		ConcBatchBytes: 32 * mib,
+	})
+	want := "    window: 512.00 MiB / 24 per-file-workers = 32.00 MiB"
+	if got != want {
+		t.Fatalf("formatStartBatchWindowLine() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatStartBatchProbeLine(t *testing.T) {
+	const mib = int64(1 << 20)
+
+	t.Run("active", func(t *testing.T) {
+		got := formatStartBatchProbeLine(1001, 96, BatchSizePlan{
+			ConcBatchBytes: 32 * mib,
+			BwCeilBytes:    4 * mib,
+		})
+		want := "    bw-probe: 1001 MiB/s / 96 conc / 2 = 4.00 MiB"
+		if got != want {
+			t.Fatalf("formatStartBatchProbeLine() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("inactive", func(t *testing.T) {
+		got := formatStartBatchProbeLine(1001, 96, BatchSizePlan{
+			ConcBatchBytes: 32 * mib,
+			BwCeilBytes:    32 * mib,
+		})
+		if got != "" {
+			t.Fatalf("expected inactive bw-probe line to be hidden, got %q", got)
+		}
+	})
+}
+
+func TestFixedWidthHumanDurationKeepsShortDurationsAligned(t *testing.T) {
+	short := fixedWidthHumanDuration(2 * time.Second)
+	longer := fixedWidthHumanDuration(10 * time.Second)
+	minute := fixedWidthHumanDuration(62 * time.Second)
+
+	if short != "  2s" {
+		t.Fatalf("unexpected short duration: %q", short)
+	}
+	if longer != " 10s" {
+		t.Fatalf("unexpected longer duration: %q", longer)
+	}
+	if minute != "1m2s" {
+		t.Fatalf("unexpected minute duration: %q", minute)
+	}
+	if len(short) != len(longer) || len(longer) != len(minute) {
+		t.Fatalf("expected fixed-width durations, got lens %d %d %d", len(short), len(longer), len(minute))
+	}
+}
+
+func TestFixedWidthETAKeepsDurationsAligned(t *testing.T) {
+	short := fixedWidthETA(57 * time.Second)
+	minute := fixedWidthETA(74 * time.Second)
+
+	if short != "  57s" {
+		t.Fatalf("unexpected short eta: %q", short)
+	}
+	if minute != " 1.2m" {
+		t.Fatalf("unexpected minute eta: %q", minute)
+	}
+	if len(short) != 5 || len(minute) != 5 {
+		t.Fatalf("expected 5-char eta fields, got %d and %d", len(short), len(minute))
+	}
+}
+
+func TestFixedWidthETANA(t *testing.T) {
+	if got := fixedWidthETANA(); got != "  n/a" {
+		t.Fatalf("unexpected n/a eta: %q", got)
+	}
+	if len(fixedWidthETANA()) != 5 {
+		t.Fatalf("expected 5-char n/a eta field, got %d", len(fixedWidthETANA()))
+	}
+}
+
+func TestCompactETAUsesFractionalUnitsEarly(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{in: 59 * time.Second, want: "59s"},
+		{in: 74 * time.Second, want: "1.2m"},
+		{in: 95 * time.Minute, want: "1.6h"},
+		{in: 36 * time.Hour, want: "1.5d"},
+		{in: 15 * 24 * time.Hour, want: "2.1w"},
+	}
+	for _, tt := range tests {
+		if got := compactETA(tt.in); got != tt.want {
+			t.Fatalf("compactETA(%s) = %q, want %q", tt.in, got, tt.want)
+		}
+		if len(tt.want) > 5 {
+			t.Fatalf("test case %q exceeds 5 chars", tt.want)
+		}
+	}
+}
+
+func TestVerbosityFromFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress bool
+		verbose  bool
+		want     int
+	}{
+		{name: "quiet", progress: false, verbose: false, want: 0},
+		{name: "progress", progress: true, verbose: false, want: 1},
+		{name: "verbose", progress: false, verbose: true, want: 2},
+		{name: "verbose wins", progress: true, verbose: true, want: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := verbosityFromFlags(tt.progress, tt.verbose); got != tt.want {
+				t.Fatalf("verbosityFromFlags(%v, %v) = %d, want %d", tt.progress, tt.verbose, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintTransferErrors(t *testing.T) {
+	buildErrors := func(n int) []error {
+		errs := make([]error, 0, n)
+		for i := 1; i <= n; i++ {
+			errs = append(errs, fmt.Errorf("boom-%d", i))
+		}
+		return errs
+	}
+
+	t.Run("no errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		printTransferErrors(&buf, "start", nil, 1)
+		if got := buf.String(); got != "" {
+			t.Fatalf("expected no output, got %q", got)
+		}
+	})
+
+	t.Run("prints first five and summary when not verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		printTransferErrors(&buf, "start", buildErrors(7), 1)
+		got := buf.String()
+		for i := 1; i <= 5; i++ {
+			want := fmt.Sprintf("start error: boom-%d\n", i)
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected output to contain %q, got %q", want, got)
+			}
+		}
+		if strings.Contains(got, "start error: boom-6\n") || strings.Contains(got, "start error: boom-7\n") {
+			t.Fatalf("expected output to truncate after five errors, got %q", got)
+		}
+		if !strings.Contains(got, "start failed with 7 errors\n") {
+			t.Fatalf("expected summary line, got %q", got)
+		}
+	})
+
+	t.Run("prints all when verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		printTransferErrors(&buf, "sync", buildErrors(6), 2)
+		got := buf.String()
+		for i := 1; i <= 6; i++ {
+			want := fmt.Sprintf("sync error: boom-%d\n", i)
+			if !strings.Contains(got, want) {
+				t.Fatalf("expected output to contain %q, got %q", want, got)
+			}
+		}
+		if strings.Contains(got, "sync failed with 6 errors\n") {
+			t.Fatalf("did not expect summary line in verbose mode, got %q", got)
+		}
+	})
+}
+
+func TestHumanBytesFixedWidthUsesPerValueUnits(t *testing.T) {
+	zero := encoding.HumanBytesFixedWidth(0, fixedWidthProgressBytesWidth)
+	mid := encoding.HumanBytesFixedWidth(492_340_000, fixedWidthProgressBytesWidth)
+	done := encoding.HumanBytesFixedWidth(1_950_000_000, fixedWidthProgressBytesWidth)
+	totalFormatted := encoding.HumanBytesFixedWidth(20_174_499_881, fixedWidthProgressBytesWidth)
+
+	if zero != "       0 B" {
+		t.Fatalf("unexpected zero progress bytes: %q", zero)
+	}
+	if mid != "469.53 MiB" || done != "  1.82 GiB" || totalFormatted != " 18.79 GiB" {
+		t.Fatalf("unexpected fixed-width byte values: %q %q %q", mid, done, totalFormatted)
+	}
+}
+
+func TestEffectiveModeLinkMbpsScalesGentleBandwidth(t *testing.T) {
+	if got := effectiveModeLinkMbps(LoadStrategyGentle, 8400, 25); got != 2100 {
+		t.Fatalf("expected gentle link mbps 2100, got %d", got)
+	}
+	if got := effectiveModeLinkMbps(LoadStrategyFast, 8400, 25); got != 8400 {
+		t.Fatalf("expected fast link mbps 8400, got %d", got)
+	}
+}
+
+func TestFormatProbeRateSuffixOmitsWhenNoProbeData(t *testing.T) {
+	if got := formatProbeRateSuffix(time.Unix(400, 0), 10, &probeReporter{}); got != "" {
+		t.Fatalf("expected empty suffix without probe data, got %q", got)
 	}
 }
 
@@ -1592,10 +1964,10 @@ func TestVerboseProgressReporterIncludesAckedBytes(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 progress lines, got %d: %q", len(lines), stderr.String())
 	}
-	if got := lines[0]; !strings.Contains(got, "file progress[42]: 20% bytes=20 B/100 B [0 B]") {
+	if got := lines[0]; !strings.Contains(got, "file progress[42]: 20% bytes=") || !strings.Contains(got, "20 B/") || !strings.Contains(got, "[       0 B]") {
 		t.Fatalf("unexpected first progress line: %q", got)
 	}
-	if got := lines[1]; !strings.Contains(got, "file progress[42]: 40% bytes=40 B/100 B [10 B]") {
+	if got := lines[1]; !strings.Contains(got, "file progress[42]: 40% bytes=") || !strings.Contains(got, "40 B/") || !strings.Contains(got, "[      10 B]") {
 		t.Fatalf("unexpected second progress line: %q", got)
 	}
 	for _, line := range lines {

--- a/server/internal/filexfer/encoding/format.go
+++ b/server/internal/filexfer/encoding/format.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+var humanByteUnits = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+var humanRateUnits = []string{"B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s", "PiB/s", "EiB/s"}
+
 func ParseByteSize(raw string) (int64, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -30,36 +33,28 @@ func ParseByteSize(raw string) (int64, error) {
 }
 
 func HumanBytes(v int64) string {
-	if v <= 0 {
-		return "0 B"
-	}
-	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
-	value := float64(v)
-	unit := 0
-	for value >= 1024 && unit < len(units)-1 {
-		value /= 1024
-		unit++
-	}
-	if unit == 0 {
-		return fmt.Sprintf("%.0f %s", value, units[unit])
-	}
-	return fmt.Sprintf("%.2f %s", value, units[unit])
+	return formatHumanBinary(float64(v), humanByteUnits, 0)
+}
+
+func HumanBytesFixedWidth(v int64, width int) string {
+	return formatHumanBinary(float64(v), humanByteUnits, width)
 }
 
 func HumanRate(bps float64) string {
-	if bps <= 0 {
-		return "0 B/s"
+	return formatHumanBinary(bps, humanRateUnits, 0)
+}
+
+func HumanRateFixedWidth(bps float64, width int) string {
+	return formatHumanBinary(bps, humanRateUnits, width)
+}
+
+func formatHumanBinary(value float64, units []string, width int) string {
+	scaled, unit, decimals := scaleHumanBinary(value, units)
+	formatted := formatHumanValue(scaled, unit, decimals)
+	if width > 0 {
+		return fmt.Sprintf("%*s", width, formatted)
 	}
-	units := []string{"B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s"}
-	unit := 0
-	for bps >= 1024 && unit < len(units)-1 {
-		bps /= 1024
-		unit++
-	}
-	if unit == 0 {
-		return fmt.Sprintf("%.0f %s", bps, units[unit])
-	}
-	return fmt.Sprintf("%.2f %s", bps, units[unit])
+	return formatted
 }
 
 func HumanCount(n uint64, width int) string {
@@ -100,6 +95,33 @@ func HumanCount(n uint64, width int) string {
 		return raw[len(raw)-width:]
 	}
 	return fmt.Sprintf("%*s", width, raw)
+}
+
+func scaleHumanBinary(value float64, units []string) (scaled float64, unit string, decimals int) {
+	if len(units) == 0 {
+		return value, "", 0
+	}
+	absValue := value
+	if absValue < 0 {
+		absValue = -absValue
+	}
+	unitIdx := 0
+	for absValue >= 1024 && unitIdx < len(units)-1 {
+		absValue /= 1024
+		value /= 1024
+		unitIdx++
+	}
+	if unitIdx == 0 {
+		return value, units[unitIdx], 0
+	}
+	return value, units[unitIdx], 2
+}
+
+func formatHumanValue(value float64, unit string, decimals int) string {
+	if decimals == 0 {
+		return fmt.Sprintf("%.0f %s", value, unit)
+	}
+	return fmt.Sprintf("%.2f %s", value, unit)
 }
 
 func parseHumanValueAndUnit(raw string) (float64, string, error) {

--- a/server/internal/filexfer/encoding/format_test.go
+++ b/server/internal/filexfer/encoding/format_test.go
@@ -49,6 +49,21 @@ func TestHumanBytes(t *testing.T) {
 	}
 }
 
+func TestHumanBytesFixedWidth(t *testing.T) {
+	if got := HumanBytesFixedWidth(0, 10); got != "       0 B" {
+		t.Fatalf("unexpected zero value: %q", got)
+	}
+	if got := HumanBytesFixedWidth(492_340_000, 10); got != "469.53 MiB" {
+		t.Fatalf("unexpected mid value: %q", got)
+	}
+	if got := HumanBytesFixedWidth(1_950_000_000, 10); got != "  1.82 GiB" {
+		t.Fatalf("unexpected gib value: %q", got)
+	}
+	if got := HumanBytesFixedWidth(20_174_499_881, 10); got != " 18.79 GiB" {
+		t.Fatalf("unexpected total value: %q", got)
+	}
+}
+
 func TestHumanRate(t *testing.T) {
 	tests := []struct {
 		in   float64
@@ -64,5 +79,17 @@ func TestHumanRate(t *testing.T) {
 		if got := HumanRate(tc.in); got != tc.want {
 			t.Fatalf("unexpected value for %f: got=%q want=%q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestHumanRateFixedWidth(t *testing.T) {
+	if got := HumanRateFixedWidth(0, 13); got != "        0 B/s" {
+		t.Fatalf("unexpected zero rate: %q", got)
+	}
+	if got := HumanRateFixedWidth(245.51*1024*1024, 13); got != " 245.51 MiB/s" {
+		t.Fatalf("unexpected mib rate: %q", got)
+	}
+	if got := HumanRateFixedWidth(1.5*1024*1024*1024, 13); got != "   1.50 GiB/s" {
+		t.Fatalf("unexpected gib rate: %q", got)
 	}
 }

--- a/server/internal/filexfer/ftcp/deps.go
+++ b/server/internal/filexfer/ftcp/deps.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 	intstore "github.com/jolynch/pinch/internal/filexfer/store"
 )
 
@@ -15,6 +16,7 @@ type TransferFileState = intstore.TransferFileState
 type TransferFileStateUpdate = intstore.TransferFileStateUpdate
 type FileRef = intstore.FileRef
 type FileLookupError = intstore.FileLookupError
+type TransferObservedLinkUpdate = intstore.TransferObservedLinkUpdate
 
 const (
 	TransferStateStarted = intstore.TransferStateStarted
@@ -32,6 +34,9 @@ type Deps interface {
 	GetTransfer(txferID string) (Transfer, bool)
 	ListTransfers() []Transfer
 	SetTransferHints(txferID string, mode string, linkMbps int64, concurrency int) bool
+	GetTransferGentleLimiter(txferID string, fallbackLinkMbps int64, gentleBWPct int, burstBytes int64) *limit.Limiter
+	ReportTransferObservedLink(txferID string, observedLinkMbps int64, gentleBWPct int, burstBytes int64, emaAlpha float64) (TransferObservedLinkUpdate, bool)
+	GetTransferLimiterBps(txferID string) int64
 	GetFile(txferID string, fileID uint64, fullPathRaw string) (*os.File, FileRef, error)
 	GetFileRef(txferID string, fileID uint64, fullPathRaw string) (FileRef, error)
 
@@ -90,6 +95,18 @@ func (runtimeDeps) ListTransfers() []Transfer {
 
 func (runtimeDeps) SetTransferHints(txferID string, mode string, linkMbps int64, concurrency int) bool {
 	return intstore.SetTransferHints(txferID, mode, linkMbps, concurrency)
+}
+
+func (runtimeDeps) GetTransferGentleLimiter(txferID string, fallbackLinkMbps int64, gentleBWPct int, burstBytes int64) *limit.Limiter {
+	return intstore.GetTransferGentleLimiter(txferID, fallbackLinkMbps, gentleBWPct, burstBytes)
+}
+
+func (runtimeDeps) ReportTransferObservedLink(txferID string, observedLinkMbps int64, gentleBWPct int, burstBytes int64, emaAlpha float64) (TransferObservedLinkUpdate, bool) {
+	return intstore.ReportTransferObservedLink(txferID, observedLinkMbps, gentleBWPct, burstBytes, emaAlpha)
+}
+
+func (runtimeDeps) GetTransferLimiterBps(txferID string) int64 {
+	return intstore.GetTransferLimiterBps(txferID)
 }
 
 func (runtimeDeps) GetFile(txferID string, fileID uint64, fullPathRaw string) (*os.File, FileRef, error) {

--- a/server/internal/filexfer/ftcp/probe.go
+++ b/server/internal/filexfer/ftcp/probe.go
@@ -5,11 +5,14 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jolynch/pinch/internal/filexfer/encoding"
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 	"github.com/jolynch/pinch/utils"
 )
 
@@ -17,9 +20,11 @@ const maxProbeBytes int64 = 32 * 1024 * 1024
 const probeCopyBufferBytes = 64 * 1024
 
 type probeRequest struct {
-	ClientCPU  int
-	ProbeBytes int64
-	ClientTS0  int64
+	ClientCPU        int
+	ProbeBytes       int64
+	ClientTS0        int64
+	TransferID       string
+	ObservedLinkMbps int64
 }
 
 func handlePROBECommand(context.Context, Request, io.Writer, Deps) error {
@@ -49,10 +54,27 @@ func parsePROBERequest(req Request) (probeRequest, error) {
 	if err != nil || clientTS0 < 0 {
 		return probeRequest{}, protocolErr{code: "BAD_REQUEST", message: "invalid PROBE cts0"}
 	}
-	return probeRequest{ClientCPU: clientCPU, ProbeBytes: probeBytes, ClientTS0: clientTS0}, nil
+	transferID := strings.TrimSpace(p["txferid"])
+	observedLinkMbps := int64(0)
+	if raw := strings.TrimSpace(p["obs-link-mbps"]); raw != "" {
+		observedLinkMbps, err = strconv.ParseInt(raw, 10, 64)
+		if err != nil || observedLinkMbps < 0 {
+			return probeRequest{}, protocolErr{code: "BAD_REQUEST", message: "invalid PROBE obs-link-mbps"}
+		}
+		if transferID == "" {
+			return probeRequest{}, protocolErr{code: "BAD_REQUEST", message: "PROBE obs-link-mbps requires txferid"}
+		}
+	}
+	return probeRequest{
+		ClientCPU:        clientCPU,
+		ProbeBytes:       probeBytes,
+		ClientTS0:        clientTS0,
+		TransferID:       transferID,
+		ObservedLinkMbps: observedLinkMbps,
+	}, nil
 }
 
-func handlePROBEWithInput(_ context.Context, req Request, in io.Reader, out io.Writer, _ Deps, ioDepth int) error {
+func handlePROBEWithInput(_ context.Context, req Request, in io.Reader, out io.Writer, deps Deps, ioDepth int, gentleCPUPct int, gentleBWPct int, gentleBurstBytes int64) error {
 	parsed, err := parsePROBERequest(req)
 	if err != nil {
 		return err
@@ -63,15 +85,33 @@ func handlePROBEWithInput(_ context.Context, req Request, in io.Reader, out io.W
 	if ioDepth <= 0 {
 		ioDepth = 8
 	}
+	gentleCPUPct = limit.NormalizeGentleCPUPct(gentleCPUPct)
+	gentleBWPct = limit.NormalizeGentleBWPct(gentleBWPct)
 	sts0 := time.Now().UnixMilli()
 	if parsed.ProbeBytes > 0 {
 		if err := drainProbePayload(in, parsed.ProbeBytes, &sts0); err != nil {
 			return protocolErr{code: "BAD_REQUEST", message: "invalid PROBE payload"}
 		}
 	}
+	if deps != nil && parsed.TransferID != "" && parsed.ObservedLinkMbps > 0 {
+		if update, ok := deps.ReportTransferObservedLink(parsed.TransferID, parsed.ObservedLinkMbps, gentleBWPct, gentleBurstBytes, 0.2); ok && update.NewRateBps != update.OldRateBps {
+			log.Printf(
+				"filexfer probe tid=%s observed_link=%dMbps ema_link=%.1fMbps limiter=%s->%s",
+				parsed.TransferID,
+				update.ObservedLinkMbps,
+				update.EMALinkMbps,
+				encoding.HumanRate(float64(update.OldRateBps)),
+				encoding.HumanRate(float64(update.NewRateBps)),
+			)
+		}
+	}
 	sts1 := time.Now().UnixMilli()
+	limiterBps := int64(0)
+	if deps != nil && parsed.TransferID != "" {
+		limiterBps = deps.GetTransferLimiterBps(parsed.TransferID)
+	}
 	respLine := fmt.Sprintf(
-		"PROBE cpu=%d io-depth=%d cts0=%d sts0=%d sts1=%d probe-bytes=%d wmem=%d\n",
+		"PROBE cpu=%d io-depth=%d cts0=%d sts0=%d sts1=%d probe-bytes=%d wmem=%d gentle-cpu-pct=%d gentle-bw-pct=%d limiter-bps=%d\n",
 		runtime.NumCPU(),
 		ioDepth,
 		parsed.ClientTS0,
@@ -79,6 +119,9 @@ func handlePROBEWithInput(_ context.Context, req Request, in io.Reader, out io.W
 		sts1,
 		parsed.ProbeBytes,
 		utils.MaxSocketWriteBufferBytes(),
+		gentleCPUPct,
+		gentleBWPct,
+		limiterBps,
 	)
 	if _, err := io.WriteString(out, respLine); err != nil {
 		return err

--- a/server/internal/filexfer/ftcp/probe_test.go
+++ b/server/internal/filexfer/ftcp/probe_test.go
@@ -8,7 +8,32 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
+
+type probeTestDeps struct {
+	sendTestDeps
+	reportTxferID  string
+	reportObserved int64
+	reportBWPct    int
+	reportBurst    int64
+	reportEMAAlpha float64
+	reportCalled   bool
+	reportReturn   TransferObservedLinkUpdate
+	reportReturnOK bool
+}
+
+func (d *probeTestDeps) ReportTransferObservedLink(txferID string, observedLinkMbps int64, gentleBWPct int, burstBytes int64, emaAlpha float64) (TransferObservedLinkUpdate, bool) {
+	d.reportCalled = true
+	d.reportTxferID = txferID
+	d.reportObserved = observedLinkMbps
+	d.reportBWPct = gentleBWPct
+	d.reportBurst = burstBytes
+	d.reportEMAAlpha = emaAlpha
+	return d.reportReturn, d.reportReturnOK
+}
+
+func (d *probeTestDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
 
 func TestHandlePROBERoundTrip(t *testing.T) {
 	req, err := ParseRequest([]byte(`PROBE cpu=8 probe-bytes=1024 cts0=100`))
@@ -18,7 +43,7 @@ func TestHandlePROBERoundTrip(t *testing.T) {
 	payload := bytes.Repeat([]byte{0x5a}, 1024)
 	in := bytes.NewReader(payload)
 	var out bytes.Buffer
-	if err := handlePROBEWithInput(context.Background(), req, in, &out, nil, 8); err != nil {
+	if err := handlePROBEWithInput(context.Background(), req, in, &out, &probeTestDeps{}, 8, 25, 25, 1*1024*1024); err != nil {
 		t.Fatalf("handlePROBEWithInput failed: %v", err)
 	}
 
@@ -40,6 +65,12 @@ func TestHandlePROBERoundTrip(t *testing.T) {
 	if got := respReq.Params[0]["io-depth"]; got != "8" {
 		t.Fatalf("expected io-depth=8, got %q", got)
 	}
+	if got := respReq.Params[0]["gentle-cpu-pct"]; got != "25" {
+		t.Fatalf("expected gentle-cpu-pct=25, got %q", got)
+	}
+	if got := respReq.Params[0]["gentle-bw-pct"]; got != "25" {
+		t.Fatalf("expected gentle-bw-pct=25, got %q", got)
+	}
 	echo := make([]byte, 1024)
 	if _, err := io.ReadFull(br, echo); err != nil {
 		t.Fatalf("read probe echo bytes: %v", err)
@@ -58,7 +89,7 @@ func TestHandlePROBEDefaultIODepth(t *testing.T) {
 		t.Fatalf("ParseRequest failed: %v", err)
 	}
 	var out bytes.Buffer
-	if err := handlePROBEWithInput(context.Background(), req, bytes.NewReader(nil), &out, nil, 0); err != nil {
+	if err := handlePROBEWithInput(context.Background(), req, bytes.NewReader(nil), &out, &probeTestDeps{}, 0, 30, 25, 1*1024*1024); err != nil {
 		t.Fatalf("handlePROBEWithInput failed: %v", err)
 	}
 	line, err := bufio.NewReader(bytes.NewReader(out.Bytes())).ReadString('\n')
@@ -72,6 +103,12 @@ func TestHandlePROBEDefaultIODepth(t *testing.T) {
 	if got := respReq.Params[0]["io-depth"]; got != "8" {
 		t.Fatalf("expected default io-depth=8, got %q", got)
 	}
+	if got := respReq.Params[0]["gentle-cpu-pct"]; got != "30" {
+		t.Fatalf("expected gentle-cpu-pct=30, got %q", got)
+	}
+	if got := respReq.Params[0]["gentle-bw-pct"]; got != "25" {
+		t.Fatalf("expected gentle-bw-pct=25, got %q", got)
+	}
 }
 
 func TestHandlePROBERejectsShortPayload(t *testing.T) {
@@ -81,9 +118,36 @@ func TestHandlePROBERejectsShortPayload(t *testing.T) {
 	}
 	in := bytes.NewReader([]byte{1, 2, 3})
 	var out bytes.Buffer
-	err = handlePROBEWithInput(context.Background(), req, in, &out, nil, 8)
+	err = handlePROBEWithInput(context.Background(), req, in, &out, &probeTestDeps{}, 8, 25, 25, 1*1024*1024)
 	if err == nil {
 		t.Fatalf("expected payload validation error")
+	}
+}
+
+func TestHandlePROBEReportsObservedLink(t *testing.T) {
+	req, err := ParseRequest([]byte(`PROBE cpu=8 probe-bytes=0 cts0=100 txferid=tx123 obs-link-mbps=900`))
+	if err != nil {
+		t.Fatalf("ParseRequest failed: %v", err)
+	}
+	deps := &probeTestDeps{
+		reportReturn:   TransferObservedLinkUpdate{ObservedLinkMbps: 900, EMALinkMbps: 900, OldRateBps: 0, NewRateBps: 28125000},
+		reportReturnOK: true,
+	}
+	var out bytes.Buffer
+	if err := handlePROBEWithInput(context.Background(), req, bytes.NewReader(nil), &out, deps, 8, 25, 25, 2*1024*1024); err != nil {
+		t.Fatalf("handlePROBEWithInput failed: %v", err)
+	}
+	if !deps.reportCalled {
+		t.Fatalf("expected ReportTransferObservedLink call")
+	}
+	if deps.reportTxferID != "tx123" || deps.reportObserved != 900 {
+		t.Fatalf("unexpected report args: tx=%s observed=%d", deps.reportTxferID, deps.reportObserved)
+	}
+	if deps.reportBWPct != 25 || deps.reportBurst != 2*1024*1024 {
+		t.Fatalf("unexpected limiter args: pct=%d burst=%d", deps.reportBWPct, deps.reportBurst)
+	}
+	if deps.reportEMAAlpha != 0.2 {
+		t.Fatalf("unexpected EMA alpha: %.2f", deps.reportEMAAlpha)
 	}
 }
 
@@ -99,5 +163,20 @@ func TestParsePROBERequestRejectsOversizedProbe(t *testing.T) {
 	_, err := parsePROBERequest(req)
 	if err == nil {
 		t.Fatalf("expected oversized probe error")
+	}
+}
+
+func TestParsePROBERequestObservedLinkRequiresTransferID(t *testing.T) {
+	req := Request{
+		Verb: VerbPROBE,
+		Params: []map[string]string{{
+			"cpu":           "4",
+			"probe-bytes":   "0",
+			"cts0":          "100",
+			"obs-link-mbps": "900",
+		}},
+	}
+	if _, err := parsePROBERequest(req); err == nil {
+		t.Fatalf("expected obs-link-mbps validation error")
 	}
 }

--- a/server/internal/filexfer/ftcp/request.go
+++ b/server/internal/filexfer/ftcp/request.go
@@ -272,7 +272,7 @@ func ParseRequest(payload []byte) (Request, error) {
 				return Request{}, protocolErr{code: "BAD_REQUEST", message: "invalid PROBE arguments"}
 			}
 			switch key {
-			case "cpu", "io-depth", "probe-bytes", "cts0", "sts0", "sts1", "wmem":
+			case "cpu", "io-depth", "probe-bytes", "cts0", "sts0", "sts1", "wmem", "txferid", "obs-link-mbps", "gentle-cpu-pct", "gentle-bw-pct":
 				param[key] = val
 			default:
 				// Unknown keys are ignored for forward compatibility.

--- a/server/internal/filexfer/ftcp/request_test.go
+++ b/server/internal/filexfer/ftcp/request_test.go
@@ -251,6 +251,16 @@ func TestParseRequestPROBE(t *testing.T) {
 	}
 }
 
+func TestParseRequestPROBEOptionalFields(t *testing.T) {
+	req, err := ParseRequest([]byte(`PROBE cpu=8 probe-bytes=1048576 cts0=100 txferid=tx1 obs-link-mbps=900 gentle-cpu-pct=30 gentle-bw-pct=40`))
+	if err != nil {
+		t.Fatalf("ParseRequest err: %v", err)
+	}
+	if req.Params[0]["txferid"] != "tx1" || req.Params[0]["obs-link-mbps"] != "900" || req.Params[0]["gentle-cpu-pct"] != "30" || req.Params[0]["gentle-bw-pct"] != "40" {
+		t.Fatalf("unexpected optional PROBE params: %#v", req.Params[0])
+	}
+}
+
 func TestParseRequestPROBEMissingRequired(t *testing.T) {
 	_, err := ParseRequest([]byte(`PROBE cpu=8 cts0=100`))
 	if err == nil {

--- a/server/internal/filexfer/ftcp/send.go
+++ b/server/internal/filexfer/ftcp/send.go
@@ -141,23 +141,17 @@ func parseSENDRequest(req Request) (sendRequest, error) {
 }
 
 func handleSEND(ctx context.Context, req Request, out io.Writer, deps Deps) error {
-	return handleSENDWithOptions(ctx, req, out, deps, nil, false)
+	return handleSENDWithOptions(ctx, req, out, deps, nil, false, 25)
 }
 
-func handleSENDWithOptions(ctx context.Context, req Request, out io.Writer, deps Deps, limiter *limit.Limiter, disableZeroCopy bool) error {
+func handleSENDWithOptions(ctx context.Context, req Request, out io.Writer, deps Deps, limiter *limit.Limiter, disableZeroCopy bool, gentleBWPct int) error {
 	parsed, err := parseSENDRequest(req)
 	if err != nil {
 		return err
 	}
+	gentleBWPct = limit.NormalizeGentleBWPct(gentleBWPct)
 
-	// Derive per-transfer gentle limiter from probed link bandwidth (25%).
-	var gentleLimiter *limit.Limiter
 	transfer, hasTransfer := deps.GetTransfer(parsed.TransferID)
-	if hasTransfer && transfer.LinkMbps > 0 {
-		derivedBps := (transfer.LinkMbps * 1_000_000 / 8) / 4
-		gentleLimiter, _ = limit.NewLimiterFromBps(derivedBps, 1*1024*1024)
-	}
-
 	for _, item := range parsed.Items {
 		itemOut := out
 		if item.Mode == loadStrategyGentle {
@@ -166,6 +160,7 @@ func handleSENDWithOptions(ctx context.Context, req Request, out io.Writer, deps
 					return err
 				}
 			}
+			gentleLimiter := deps.GetTransferGentleLimiter(parsed.TransferID, transfer.LinkMbps, gentleBWPct, gentleLimiterBurstBytes(limiter))
 			if gentleLimiter != nil {
 				itemOut = gentleLimiter.WrapRateLimitedWriter(itemOut, ctx)
 			}

--- a/server/internal/filexfer/ftcp/send.go
+++ b/server/internal/filexfer/ftcp/send.go
@@ -27,7 +27,6 @@ const defaultFileFrameLogicalSize int64 = 4 * 1024 * 1024
 const defaultCompressedFrameBufferBytes = 4 * 1024 * 1024
 const defaultMaxLinuxPipeSizeBytes int64 = 1 * 1024 * 1024
 const maxCompressedFrameBufferPoolBytes = 32 * 1024 * 1024
-const placeholderHeaderHashToken = "xxh128:00000000000000000000000000000000"
 const loadStrategyFast = "fast"
 const loadStrategyGentle = "gentle"
 
@@ -589,7 +588,7 @@ func buildFrameHeaderLine(fileID uint64, offset int64, size int64, wireSize int6
 			" offset=" + strconv.FormatInt(offset, 10) +
 			" size=" + strconv.FormatInt(size, 10) +
 			" wsize=" + strconv.FormatInt(wireSize, 10) +
-			" comp=" + comp + " hash=" + placeholderHeaderHashToken +
+			" comp=" + comp +
 			" max-wsize=" + strconv.FormatInt(*maxWSizeHint, 10) +
 			" ts=" + strconv.FormatInt(ts, 10) + "\n"
 	}
@@ -597,7 +596,7 @@ func buildFrameHeaderLine(fileID uint64, offset int64, size int64, wireSize int6
 		" offset=" + strconv.FormatInt(offset, 10) +
 		" size=" + strconv.FormatInt(size, 10) +
 		" wsize=" + strconv.FormatInt(wireSize, 10) +
-		" comp=" + comp + " hash=" + placeholderHeaderHashToken +
+		" comp=" + comp +
 		" ts=" + strconv.FormatInt(ts, 10) + "\n"
 }
 

--- a/server/internal/filexfer/ftcp/send_test.go
+++ b/server/internal/filexfer/ftcp/send_test.go
@@ -153,6 +153,16 @@ func TestParseSENDRequestCompDefaultsAndModes(t *testing.T) {
 	}
 }
 
+func TestBuildFrameHeaderLineOmitsPlaceholderHash(t *testing.T) {
+	header := buildFrameHeaderLine(7, 0, 5, 5, "none", nil, 1000)
+	if strings.Contains(header, " hash=") {
+		t.Fatalf("expected FTCP SEND header to omit placeholder hash, got %q", header)
+	}
+	if !strings.Contains(header, " comp=none ts=1000") {
+		t.Fatalf("unexpected header contents: %q", header)
+	}
+}
+
 func TestParseSENDRequestModeDefaultsAndValidation(t *testing.T) {
 	req, err := ParseRequest([]byte(`SEND tx1 fd=1 "/tmp/a.txt"`))
 	if err != nil {

--- a/server/internal/filexfer/ftcp/send_test.go
+++ b/server/internal/filexfer/ftcp/send_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jolynch/pinch/internal/filexfer/encoding"
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 	"github.com/zeebo/xxh3"
 )
 
@@ -44,6 +45,12 @@ func (d *sendTestDeps) GetTransfer(string) (Transfer, bool) { return Transfer{},
 func (d *sendTestDeps) ListTransfers() []Transfer           { return nil }
 
 func (d *sendTestDeps) SetTransferHints(string, string, int64, int) bool { return true }
+func (d *sendTestDeps) GetTransferGentleLimiter(string, int64, int, int64) *limit.Limiter {
+	return nil
+}
+func (d *sendTestDeps) ReportTransferObservedLink(string, int64, int, int64, float64) (TransferObservedLinkUpdate, bool) {
+	return TransferObservedLinkUpdate{}, false
+}
 
 func (d *sendTestDeps) GetFile(txferID string, fileID uint64, fullPathRaw string) (*os.File, FileRef, error) {
 	fd, err := os.Open(d.filePath)
@@ -97,6 +104,7 @@ func (d *sendTestDeps) AcknowledgeTransferFile(string, uint64, int64) bool { ret
 func (d *sendTestDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (d *sendTestDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
 func (d *sendTestDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (d *sendTestDeps) GetTransferLimiterBps(string) int64                { return 0 }
 func (d *sendTestDeps) Root() string                                     { return "/" }
 
 func TestParseSENDRequestCompDefaultsAndModes(t *testing.T) {

--- a/server/internal/filexfer/ftcp/server.go
+++ b/server/internal/filexfer/ftcp/server.go
@@ -20,11 +20,24 @@ const (
 	maxCommandLineBytes = 4 * 1024 * 1024
 )
 
+func gentleLimiterBurstBytes(limiter *limit.Limiter) int64 {
+	if limiter == nil {
+		return 1 * 1024 * 1024
+	}
+	cfg := limiter.Config()
+	if cfg.BurstBytes > 0 {
+		return cfg.BurstBytes
+	}
+	return 1 * 1024 * 1024
+}
+
 type ServerOptions struct {
 	RequireAuth            bool
 	ServerIdentity         *age.X25519Identity
 	Deps                   Deps
 	Limiter                *limit.Limiter
+	GentleCPUPct           int
+	GentleBWPct            int
 	SocketWriteBufferBytes int
 	SyncTimeout            time.Duration // 0 = no timeout; bounds SYNC response write time
 	RootDir                string        // "/" or "" means unrestricted
@@ -102,6 +115,8 @@ type connSession struct {
 	serverID               *age.X25519Identity
 	deps                   Deps
 	limiter                *limit.Limiter
+	gentleCPUPct           int
+	gentleBWPct            int
 	socketWriteBufferBytes int
 	syncTimeout            time.Duration
 	disableZeroCopy        bool
@@ -120,6 +135,8 @@ func handleConn(conn net.Conn, opts ServerOptions, deps Deps, onTransferCreated 
 		serverID:               opts.ServerIdentity,
 		deps:                   deps,
 		limiter:                opts.Limiter,
+		gentleCPUPct:           opts.GentleCPUPct,
+		gentleBWPct:            opts.GentleBWPct,
 		socketWriteBufferBytes: opts.SocketWriteBufferBytes,
 		syncTimeout:            opts.SyncTimeout,
 		disableZeroCopy:        opts.DisableZeroCopy,
@@ -215,10 +232,10 @@ func (s *connSession) run() error {
 
 func (s *connSession) handleCommand(ctx context.Context, req Request, in io.Reader, out io.Writer) error {
 	if req.Verb == VerbSEND {
-		return handleSENDWithOptions(ctx, req, out, s.deps, s.limiter, s.disableZeroCopy)
+		return handleSENDWithOptions(ctx, req, out, s.deps, s.limiter, s.disableZeroCopy, s.gentleBWPct)
 	}
 	if req.Verb == VerbPROBE {
-		return handlePROBEWithInput(ctx, req, in, out, s.deps, s.targetIODepth)
+		return handlePROBEWithInput(ctx, req, in, out, s.deps, s.targetIODepth, s.gentleCPUPct, s.gentleBWPct, gentleLimiterBurstBytes(s.limiter))
 	}
 	if req.Verb == VerbSYNC {
 		if s.syncTimeout > 0 {

--- a/server/internal/filexfer/ftcp/status_test.go
+++ b/server/internal/filexfer/ftcp/status_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 )
 
 type fakeDeps struct {
@@ -23,6 +25,12 @@ func (f fakeDeps) RegisterTransferFileState(string, <-chan TransferFileStateUpda
 }
 func (f fakeDeps) ClipTransfer(string) bool                         { return true }
 func (f fakeDeps) SetTransferHints(string, string, int64, int) bool { return true }
+func (f fakeDeps) GetTransferGentleLimiter(string, int64, int, int64) *limit.Limiter {
+	return nil
+}
+func (f fakeDeps) ReportTransferObservedLink(string, int64, int, int64, float64) (TransferObservedLinkUpdate, bool) {
+	return TransferObservedLinkUpdate{}, false
+}
 func (f fakeDeps) GetTransfer(string) (Transfer, bool) {
 	return f.transfer, f.transferOK
 }
@@ -45,6 +53,7 @@ func (f fakeDeps) AcknowledgeTransferFile(string, uint64, int64) bool { return t
 func (f fakeDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (f fakeDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
 func (f fakeDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (f fakeDeps) GetTransferLimiterBps(string) int64                { return 0 }
 func (f fakeDeps) Root() string                                     { return "/" }
 
 func TestHandleSTATUSWritesStatusLine(t *testing.T) {

--- a/server/internal/filexfer/ftcp/txfer_test.go
+++ b/server/internal/filexfer/ftcp/txfer_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 )
 
 type txferTestDeps struct {
@@ -35,7 +37,7 @@ func (d *txferTestDeps) RegisterTransferFileState(string, <-chan TransferFileSta
 func (d *txferTestDeps) ClipTransfer(string) bool { return true }
 
 func (d *txferTestDeps) GetTransfer(string) (Transfer, bool) { return Transfer{}, false }
-func (d *txferTestDeps) ListTransfers() []Transfer              { return nil }
+func (d *txferTestDeps) ListTransfers() []Transfer           { return nil }
 
 func (d *txferTestDeps) SetTransferHints(txferID string, mode string, linkMbps int64, concurrency int) bool {
 	d.setHintsCalls++
@@ -44,6 +46,14 @@ func (d *txferTestDeps) SetTransferHints(txferID string, mode string, linkMbps i
 	d.setHintsMbps = linkMbps
 	d.setHintsConc = concurrency
 	return true
+}
+
+func (d *txferTestDeps) GetTransferGentleLimiter(string, int64, int, int64) *limit.Limiter {
+	return nil
+}
+
+func (d *txferTestDeps) ReportTransferObservedLink(string, int64, int, int64, float64) (TransferObservedLinkUpdate, bool) {
+	return TransferObservedLinkUpdate{}, false
 }
 
 func (d *txferTestDeps) GetFile(string, uint64, string) (*os.File, FileRef, error) {
@@ -65,6 +75,7 @@ func (d *txferTestDeps) AcknowledgeTransferFile(string, uint64, int64) bool { re
 func (d *txferTestDeps) SetTransferDeadline(string, int64) bool           { return false }
 func (d *txferTestDeps) RecordTransferFirstSend(string) (time.Time, bool) { return time.Time{}, false }
 func (d *txferTestDeps) MarkTransferTooSlow(string) bool                  { return false }
+func (d *txferTestDeps) GetTransferLimiterBps(string) int64                { return 0 }
 func (d *txferTestDeps) Root() string                                     { return "/" }
 
 func TestParseTXFERRequestRequiresHints(t *testing.T) {

--- a/server/internal/filexfer/limit/limit.go
+++ b/server/internal/filexfer/limit/limit.go
@@ -44,6 +44,25 @@ type Limiter struct {
 
 const defaultBurstBytes int64 = 1 * 1024 * 1024 // 1 MiB
 
+const (
+	DefaultGentleCPUPct = 25
+	DefaultGentleBWPct  = 25
+)
+
+func NormalizeGentleCPUPct(v int) int {
+	if v <= 0 {
+		return DefaultGentleCPUPct
+	}
+	return v
+}
+
+func NormalizeGentleBWPct(v int) int {
+	if v <= 0 {
+		return DefaultGentleBWPct
+	}
+	return v
+}
+
 // NewLimiterFromBps creates a Limiter from a numeric bytes-per-second rate.
 // If burstBytes <= 0, a 1 MiB default burst is used.
 func NewLimiterFromBps(rateBps int64, burstBytes int64) (*Limiter, error) {

--- a/server/internal/filexfer/limit/limit_test.go
+++ b/server/internal/filexfer/limit/limit_test.go
@@ -111,3 +111,18 @@ func TestNewLimiterRejectsBurstWhenRateEnabled(t *testing.T) {
 		t.Fatalf("expected error for zero burst when rate enabled")
 	}
 }
+
+func TestNormalizeGentlePercents(t *testing.T) {
+	if got := NormalizeGentleCPUPct(0); got != DefaultGentleCPUPct {
+		t.Fatalf("NormalizeGentleCPUPct(0) = %d, want %d", got, DefaultGentleCPUPct)
+	}
+	if got := NormalizeGentleCPUPct(40); got != 40 {
+		t.Fatalf("NormalizeGentleCPUPct(40) = %d, want 40", got)
+	}
+	if got := NormalizeGentleBWPct(-1); got != DefaultGentleBWPct {
+		t.Fatalf("NormalizeGentleBWPct(-1) = %d, want %d", got, DefaultGentleBWPct)
+	}
+	if got := NormalizeGentleBWPct(60); got != 60 {
+		t.Fatalf("NormalizeGentleBWPct(60) = %d, want 60", got)
+	}
+}

--- a/server/internal/filexfer/store/store.go
+++ b/server/internal/filexfer/store/store.go
@@ -4,15 +4,18 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	intencoding "github.com/jolynch/pinch/internal/filexfer/encoding"
+	"github.com/jolynch/pinch/internal/filexfer/limit"
 	"github.com/jolynch/pinch/internal/filexfer/policy"
 	"github.com/zeebo/xxh3"
 )
@@ -93,6 +96,9 @@ type managedTransfer struct {
 	transfer     Transfer
 	fileHashes   map[uint64]fileHashState
 	windowHashes map[windowHashKey]*windowHashState
+	observedEMA  float64
+	limiterBps   int64
+	limiter      atomic.Pointer[limit.Limiter]
 }
 
 type transferStore struct {
@@ -119,6 +125,14 @@ type windowHashKey struct {
 type windowHashState struct {
 	hashToken string
 	expiresAt time.Time
+}
+
+type TransferObservedLinkUpdate struct {
+	ObservedLinkMbps int64
+	EMALinkMbps      float64
+	RoundedLinkMbps  int64
+	OldRateBps       int64
+	NewRateBps       int64
 }
 
 // AckEntry is a single (transfer, file, ackBytes) tuple for batch acknowledgement.
@@ -214,7 +228,124 @@ func (s *transferStore) setTransferHints(txferID string, mode string, linkMbps i
 	managed.transfer.Mode = strings.ToLower(strings.TrimSpace(mode))
 	managed.transfer.LinkMbps = linkMbps
 	managed.transfer.Concurrency = concurrency
+	if linkMbps > 0 {
+		managed.observedEMA = float64(linkMbps)
+	}
 	return true
+}
+
+func deriveGentleRateBps(linkMbps int64, gentleBWPct int) int64 {
+	if linkMbps <= 0 || gentleBWPct <= 0 {
+		return 0
+	}
+	return (((linkMbps * 1_000_000) / 8) * int64(gentleBWPct)) / 100
+}
+
+func (s *transferStore) getOrInitGentleLimiter(txferID string, fallbackLinkMbps int64, gentleBWPct int, burstBytes int64) *limit.Limiter {
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return nil
+	}
+	if limiter := managed.limiter.Load(); limiter != nil {
+		return limiter
+	}
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return nil
+	}
+	if limiter := managed.limiter.Load(); limiter != nil {
+		return limiter
+	}
+
+	linkMbps := int64(math.Round(managed.observedEMA))
+	if linkMbps <= 0 {
+		linkMbps = managed.transfer.LinkMbps
+	}
+	if linkMbps <= 0 {
+		linkMbps = fallbackLinkMbps
+	}
+	if linkMbps <= 0 {
+		return nil
+	}
+	rateBps := deriveGentleRateBps(linkMbps, gentleBWPct)
+	if rateBps <= 0 {
+		return nil
+	}
+	limiter, err := limit.NewLimiterFromBps(rateBps, burstBytes)
+	if err != nil {
+		return nil
+	}
+	managed.transfer.LinkMbps = linkMbps
+	if managed.observedEMA <= 0 {
+		managed.observedEMA = float64(linkMbps)
+	}
+	managed.limiterBps = rateBps
+	managed.limiter.Store(limiter)
+	return limiter
+}
+
+func (s *transferStore) getTransferLimiterBps(txferID string) int64 {
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return 0
+	}
+	managed.mu.RLock()
+	defer managed.mu.RUnlock()
+	return managed.limiterBps
+}
+
+func (s *transferStore) reportObservedLink(txferID string, observedLinkMbps int64, gentleBWPct int, burstBytes int64, emaAlpha float64) (TransferObservedLinkUpdate, bool) {
+	managed, ok := s.getManagedTransfer(txferID)
+	if !ok {
+		return TransferObservedLinkUpdate{}, false
+	}
+	if observedLinkMbps <= 0 {
+		return TransferObservedLinkUpdate{}, false
+	}
+	if emaAlpha <= 0 || emaAlpha > 1 {
+		emaAlpha = 0.2
+	}
+
+	managed.mu.Lock()
+	defer managed.mu.Unlock()
+	if managed.deleted {
+		return TransferObservedLinkUpdate{}, false
+	}
+
+	ema := float64(observedLinkMbps)
+	if managed.observedEMA > 0 {
+		ema = (emaAlpha * float64(observedLinkMbps)) + ((1 - emaAlpha) * managed.observedEMA)
+	}
+	roundedLinkMbps := int64(math.Round(ema))
+	if roundedLinkMbps <= 0 {
+		roundedLinkMbps = observedLinkMbps
+	}
+	newRateBps := deriveGentleRateBps(roundedLinkMbps, gentleBWPct)
+	update := TransferObservedLinkUpdate{
+		ObservedLinkMbps: observedLinkMbps,
+		EMALinkMbps:      ema,
+		RoundedLinkMbps:  roundedLinkMbps,
+		OldRateBps:       managed.limiterBps,
+		NewRateBps:       newRateBps,
+	}
+
+	managed.observedEMA = ema
+	managed.transfer.LinkMbps = roundedLinkMbps
+	if newRateBps <= 0 {
+		return update, true
+	}
+	if newRateBps == managed.limiterBps && managed.limiter.Load() != nil {
+		return update, true
+	}
+	limiter, err := limit.NewLimiterFromBps(newRateBps, burstBytes)
+	if err != nil {
+		return TransferObservedLinkUpdate{}, false
+	}
+	managed.limiterBps = newRateBps
+	managed.limiter.Store(limiter)
+	return update, true
 }
 
 func (s *transferStore) setTransferDeadline(txferID string, deadlineMS int64) bool {
@@ -896,6 +1027,18 @@ func GetTransfer(txferID string) (Transfer, bool) {
 
 func SetTransferHints(txferID string, mode string, linkMbps int64, concurrency int) bool {
 	return manager.setTransferHints(txferID, mode, linkMbps, concurrency)
+}
+
+func GetTransferGentleLimiter(txferID string, fallbackLinkMbps int64, gentleBWPct int, burstBytes int64) *limit.Limiter {
+	return manager.getOrInitGentleLimiter(txferID, fallbackLinkMbps, gentleBWPct, burstBytes)
+}
+
+func ReportTransferObservedLink(txferID string, observedLinkMbps int64, gentleBWPct int, burstBytes int64, emaAlpha float64) (TransferObservedLinkUpdate, bool) {
+	return manager.reportObservedLink(txferID, observedLinkMbps, gentleBWPct, burstBytes, emaAlpha)
+}
+
+func GetTransferLimiterBps(txferID string) int64 {
+	return manager.getTransferLimiterBps(txferID)
 }
 
 func SetTransferDeadline(txferID string, deadlineMS int64) bool {

--- a/server/internal/filexfer/store/store_test.go
+++ b/server/internal/filexfer/store/store_test.go
@@ -724,6 +724,81 @@ func TestGetFileSuccess(t *testing.T) {
 	}
 }
 
+func TestGetTransferGentleLimiterInitializesFromHints(t *testing.T) {
+	resetTransferStore()
+
+	transfer, err := NewTransfer("/tmp/x", 0, 0)
+	if err != nil {
+		t.Fatalf("NewTransfer returned error: %v", err)
+	}
+	if ok := SetTransferHints(transfer.ID, "gentle", 800, 6); !ok {
+		t.Fatalf("SetTransferHints failed")
+	}
+
+	limiter := GetTransferGentleLimiter(transfer.ID, 0, 25, 2*1024*1024)
+	if limiter == nil {
+		t.Fatalf("expected limiter")
+	}
+	cfg := limiter.Config()
+	if cfg.RateBps != 25_000_000 {
+		t.Fatalf("unexpected rate: got=%d want=%d", cfg.RateBps, 25_000_000)
+	}
+	if cfg.BurstBytes != 2*1024*1024 {
+		t.Fatalf("unexpected burst: got=%d", cfg.BurstBytes)
+	}
+}
+
+func TestReportTransferObservedLinkUpdatesEMAAndLimiter(t *testing.T) {
+	resetTransferStore()
+
+	transfer, err := NewTransfer("/tmp/x", 0, 0)
+	if err != nil {
+		t.Fatalf("NewTransfer returned error: %v", err)
+	}
+	if ok := SetTransferHints(transfer.ID, "gentle", 1000, 6); !ok {
+		t.Fatalf("SetTransferHints failed")
+	}
+	initial := GetTransferGentleLimiter(transfer.ID, 0, 25, 1*1024*1024)
+	if initial == nil {
+		t.Fatalf("expected initial limiter")
+	}
+
+	update, ok := ReportTransferObservedLink(transfer.ID, 500, 25, 1*1024*1024, 0.2)
+	if !ok {
+		t.Fatalf("expected report update")
+	}
+	if update.ObservedLinkMbps != 500 {
+		t.Fatalf("unexpected observed link: %d", update.ObservedLinkMbps)
+	}
+	if update.OldRateBps != 31_250_000 {
+		t.Fatalf("unexpected old rate: %d", update.OldRateBps)
+	}
+	if update.RoundedLinkMbps != 900 {
+		t.Fatalf("unexpected rounded ema link: %d", update.RoundedLinkMbps)
+	}
+	if update.NewRateBps != 28_125_000 {
+		t.Fatalf("unexpected new rate: %d", update.NewRateBps)
+	}
+	stored, ok := GetTransfer(transfer.ID)
+	if !ok {
+		t.Fatalf("expected stored transfer")
+	}
+	if stored.LinkMbps != 900 {
+		t.Fatalf("unexpected stored link mbps: %d", stored.LinkMbps)
+	}
+	updatedLimiter := GetTransferGentleLimiter(transfer.ID, 0, 25, 1*1024*1024)
+	if updatedLimiter == nil {
+		t.Fatalf("expected updated limiter")
+	}
+	if updatedLimiter == initial {
+		t.Fatalf("expected limiter swap")
+	}
+	cfg := updatedLimiter.Config()
+	if cfg.RateBps != 28_125_000 {
+		t.Fatalf("unexpected updated limiter rate: %d", cfg.RateBps)
+	}
+}
+
 func BenchmarkTransferStoreConcurrentHotPaths(b *testing.B) {
 	resetTransferStore()
 

--- a/server/main.go
+++ b/server/main.go
@@ -43,6 +43,21 @@ var (
 	fsFileBurst  = "1MiB"
 )
 
+func parsePercentFlag(raw string, name string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasSuffix(raw, "%") {
+		return 0, fmt.Errorf("%s must be an integer percent like 25%%", name)
+	}
+	value, err := strconv.Atoi(strings.TrimSpace(strings.TrimSuffix(raw, "%")))
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer percent like 25%%", name)
+	}
+	if value < 1 || value > 100 {
+		return 0, fmt.Errorf("%s must be between 1%% and 100%%", name)
+	}
+	return value, nil
+}
+
 // loadServerAgeIdentity loads an age identity from the key file in dir.
 // It returns the identity if found, or an error if the file exists but is unreadable/invalid.
 // If the key file does not exist, it returns (nil, nil).
@@ -863,6 +878,8 @@ Options:
   -l, --listen string         listen address (default "127.0.0.1:3453")
   -b, --bwlimit string        response rate limit for gentle transfers only; fast transfers do not respect it (e.g. 100MiB, 1000mbps)
       --bwlimit-burst string  rate limit burst size (default "1MiB")
+      --gentle-cpu string     percent of server CPUs advertised for gentle concurrency (default "25%")
+      --gentle-bw string      percent of observed link bandwidth used for gentle limiting (default "25%")
   -c, --chroot string         server root directory (default "/")
   -k, --keys string           age keys directory (default "/var/lib/pinch/keys")
       --require-auth          require AUTH before commands
@@ -878,6 +895,10 @@ Options:
 	fs.StringVar(&fsFileRate, "bwlimit", fsFileRate, "")
 	fs.StringVar(&fsFileRate, "b", fsFileRate, "")
 	fs.StringVar(&fsFileBurst, "bwlimit-burst", fsFileBurst, "")
+	gentleCPURaw := fmt.Sprintf("%d%%", limit.DefaultGentleCPUPct)
+	gentleBWRaw := fmt.Sprintf("%d%%", limit.DefaultGentleBWPct)
+	fs.StringVar(&gentleCPURaw, "gentle-cpu", gentleCPURaw, "")
+	fs.StringVar(&gentleBWRaw, "gentle-bw", gentleBWRaw, "")
 	var chroot string
 	fs.StringVar(&chroot, "chroot", "/", "")
 	fs.StringVar(&chroot, "c", "/", "")
@@ -902,6 +923,14 @@ Options:
 	progressInterval, err := time.ParseDuration(progressIntervalRaw)
 	if err != nil {
 		log.Fatalf("Invalid --progress-path-interval: %v", err)
+	}
+	gentleCPUPct, err := parsePercentFlag(gentleCPURaw, "--gentle-cpu")
+	if err != nil {
+		log.Fatalf("Invalid --gentle-cpu: %v", err)
+	}
+	gentleBWPct, err := parsePercentFlag(gentleBWRaw, "--gentle-bw")
+	if err != nil {
+		log.Fatalf("Invalid --gentle-bw: %v", err)
 	}
 
 	if *traceFile != "" {
@@ -944,6 +973,8 @@ Options:
 		RequireAuth:            *requireAuth,
 		ServerIdentity:         serverKey,
 		Limiter:                fileStreamLimiter,
+		GentleCPUPct:           gentleCPUPct,
+		GentleBWPct:            gentleBWPct,
 		SocketWriteBufferBytes: socketWriteBufBytes,
 		RootDir:                chroot,
 		ProgressPath:           progressFilePath,

--- a/server/main.go
+++ b/server/main.go
@@ -861,7 +861,7 @@ Start the file transfer TCP server.
 
 Options:
   -l, --listen string         listen address (default "127.0.0.1:3453")
-  -b, --bwlimit string        response rate limit (e.g. 100MiB, 1000mbps)
+  -b, --bwlimit string        response rate limit for gentle transfers only; fast transfers do not respect it (e.g. 100MiB, 1000mbps)
       --bwlimit-burst string  rate limit burst size (default "1MiB")
   -c, --chroot string         server root directory (default "/")
   -k, --keys string           age keys directory (default "/var/lib/pinch/keys")

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -2,24 +2,37 @@ package main
 
 import "testing"
 
-func TestShouldRunCLI(t *testing.T) {
+func TestParsePercentFlag(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want bool
+		name    string
+		raw     string
+		want    int
+		wantErr bool
 	}{
-		{name: "empty", args: nil, want: false},
-		{name: "binary only", args: []string{"pinch"}, want: false},
-		{name: "filecli mode", args: []string{"pinch", "filecli"}, want: true},
-		{name: "server mode", args: []string{"pinch", "-listen", ":9090"}, want: false},
-		{name: "old cli mode", args: []string{"pinch", "cli"}, want: false},
+		{name: "default", raw: "25%", want: 25},
+		{name: "min", raw: "1%", want: 1},
+		{name: "max", raw: "100%", want: 100},
+		{name: "missing percent", raw: "25", wantErr: true},
+		{name: "decimal", raw: "25.0%", wantErr: true},
+		{name: "zero", raw: "0%", wantErr: true},
+		{name: "too large", raw: "101%", wantErr: true},
+		{name: "negative", raw: "-1%", wantErr: true},
+		{name: "empty", raw: "", wantErr: true},
 	}
-
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if got := shouldRunCLI(tc.args); got != tc.want {
-				t.Fatalf("shouldRunCLI(%v)=%v want %v", tc.args, got, tc.want)
+			got, err := parsePercentFlag(tc.raw, "--gentle-cpu")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("unexpected value: got=%d want=%d", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Continue fine-tuning the concurrency and bw tuning.

Now we properly keep the IO depth limited in gentle cases, and print more understandable summaries to the console for the operator.